### PR TITLE
feat(downloader): add datetime parameter support for dynamic proxy URLs

### DIFF
--- a/internal/load.go
+++ b/internal/load.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	"log"
 	"strings"
+	"fmt"
+	"time"
 )
 
 func Load(proto string, content []byte) error {
@@ -35,6 +37,58 @@ func Load(proto string, content []byte) error {
 	return nil
 }
 
+func roundToNearestJoyDeployHour(currentHour int) int {
+	// joy-deploy uses: 00, 06, 12, 18 (4-hour increments)
+	joyDeployHours := []int{0, 6, 12, 18}
+	
+	closest := 0
+	minDiff := 24
+	
+	for _, joyHour := range joyDeployHours {
+		diff := currentHour - joyHour
+		if diff < 0 {
+			diff = -diff
+		}
+
+		if diff > 12 {
+			diff = 24 - diff
+		}
+		
+		if diff < minDiff {
+			minDiff = diff
+			closest = joyHour
+		}
+	}
+	
+	return closest
+}
+
+func replaceDateTimeTokens(url string) string {
+	now := time.Now()
+
+	hour := now.Hour()
+	minute := now.Minute()
+	if strings.Contains(url, "joy-deploy/free-proxy-list") {
+		hour = roundToNearestJoyDeployHour(hour)
+		minute = 0
+	}
+
+	replacements := map[string]string{
+		"{YYYY}": fmt.Sprintf("%04d", now.Year()),
+		"{MM}":   fmt.Sprintf("%02d", now.Month()),
+		"{DD}":   fmt.Sprintf("%02d", now.Day()),
+		"{HH}":   fmt.Sprintf("%02d", hour),
+		"{mm}":   fmt.Sprintf("%02d", minute),
+		"{M}":    fmt.Sprintf("%d", now.Month()),
+	}
+
+	for token, val := range replacements {
+		url = strings.ReplaceAll(url, token, val)
+	}
+
+	return url
+}
+
 func parseLine(line string) (string, Transformer, Parser) {
 
 	if strings.HasPrefix(line, "https://") || strings.HasPrefix(line, "http://") {
@@ -45,7 +99,7 @@ func parseLine(line string) (string, Transformer, Parser) {
 		parser := ParseProxyURL
 
 		if len(items) > 0 {
-			src = strings.TrimSpace(items[0])
+			src = replaceDateTimeTokens(strings.TrimSpace(items[0]))
 		}
 
 		if len(items) > 1 {

--- a/internal/load.go
+++ b/internal/load.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"fmt"
 	"time"
+	"regexp"
+	"strconv"
 )
 
 func Load(proto string, content []byte) error {
@@ -37,41 +39,54 @@ func Load(proto string, content []byte) error {
 	return nil
 }
 
-func roundToNearestJoyDeployHour(currentHour int) int {
-	// joy-deploy uses: 00, 06, 12, 18 (4-hour increments)
-	joyDeployHours := []int{0, 6, 12, 18}
+func roundToNearestIncrement(currentHour int, increment int) int {
+	if increment <= 0 || increment > 24 {
+		return currentHour
+	}
+	
+	// Generate valid hours based on increment
+	var validHours []int
+	for h := 0; h < 24; h += increment {
+		validHours = append(validHours, h)
+	}
 	
 	closest := 0
 	minDiff := 24
 	
-	for _, joyHour := range joyDeployHours {
-		diff := currentHour - joyHour
+	for _, validHour := range validHours {
+		diff := currentHour - validHour
 		if diff < 0 {
 			diff = -diff
 		}
-
 		if diff > 12 {
 			diff = 24 - diff
 		}
 		
 		if diff < minDiff {
 			minDiff = diff
-			closest = joyHour
+			closest = validHour
 		}
 	}
 	
 	return closest
 }
 
-func replaceDateTimeTokens(url string) string {
+func applyTokenizer(url string) string {
 	now := time.Now()
 
 	hour := now.Hour()
 	minute := now.Minute()
-	if strings.Contains(url, "joy-deploy/free-proxy-list") {
-		hour = roundToNearestJoyDeployHour(hour)
-		minute = 0
-	}
+	// Handle {HH/N} tokens with regex
+	hhIncrementRegex := regexp.MustCompile(`\{HH/(\d+)\}`)
+	url = hhIncrementRegex.ReplaceAllStringFunc(url, func(match string) string {
+		incrementStr := hhIncrementRegex.FindStringSubmatch(match)[1]
+		increment, err := strconv.Atoi(incrementStr)
+		if err != nil {
+			return match
+		}
+		roundedHour := roundToNearestIncrement(hour, increment)
+		return fmt.Sprintf("%02d", roundedHour)
+	})
 
 	replacements := map[string]string{
 		"{YYYY}": fmt.Sprintf("%04d", now.Year()),
@@ -99,7 +114,7 @@ func parseLine(line string) (string, Transformer, Parser) {
 		parser := ParseProxyURL
 
 		if len(items) > 0 {
-			src = replaceDateTimeTokens(strings.TrimSpace(items[0]))
+			src = applyTokenizer(strings.TrimSpace(items[0]))
 		}
 
 		if len(items) > 1 {

--- a/sources/https.txt
+++ b/sources/https.txt
@@ -53,3 +53,5 @@ https://github.com/murtaja89/public-proxies/raw/refs/heads/main/proxies_all.txt
 https://github.com/dinoz0rg/proxy-list/raw/refs/heads/main/scraped_proxies/http.txt
 https://raw.githubusercontent.com/parserpp/ip_ports/refs/heads/main/proxyinfo.txt
 https://raw.githubusercontent.com/Firmfox/Proxify/refs/heads/main/proxies/https.txt
+https://raw.githubusercontent.com/joy-deploy/free-proxy-list/refs/heads/main/data/{YYYY}-{MM}/{DD}/{HH/4}-00/proxies.txt
+https://a.nodeshare.xyz/uploads/{YYYY}/{M}/{YYYY}{MM}{DD}.txt


### PR DESCRIPTION
Closes #15.

This PR adds support for downloading proxy lists from URLs containing datetime placeholders, enabling dynamic source URLs that change based on current date/time.

## Summary

- Add `replaceDateTimeTokens()` function** to resolve datetime placeholders in source URLs
- Support datetime tokens: `{YYYY}`, `{MM}`, `{DD}`, `{HH}`, `{mm}`, `{M}`
- Special handling for joy-deploy URLs with 4-hour increments (00, 06, 12, 18)
- Integrate datetime replacement into `parseLine()` function in `load.go`

## Example Usage

Source URL with datetime tokens:
```
https://raw.githubusercontent.com/joy-deploy/free-proxy-list/refs/heads/main/data/{YYYY}-{MM}/{DD}/{HH}-{mm}/proxies.txt
```

Gets resolved to (example for July 10, 2025 at 15:30):
```
https://raw.githubusercontent.com/joy-deploy/free-proxy-list/refs/heads/main/data/2025-07/10/18-00/proxies.txt
```

A source link such as 
```
https://a.nodeshare.xyz/uploads/{YYYY}/{M}/{YYYY}{MM}{DD}.txt
```
Gets resolved to (example for July 10, 2025 at 20:30):
```
https://a.nodeshare.xyz/uploads/2025/7/20250710.txt
```

## Supported Tokens

- `{YYYY}` → 4-digit year (e.g., 2025)
- `{MM}` → 2-digit month with leading zero (e.g., 07)
- `{DD}` → 2-digit day with leading zero (e.g., 10)
- `{HH}` → 2-digit hour with leading zero (e.g., 18)
- `{mm}` → 2-digit minute with leading zero (e.g., 00)
- `{M}` → 1-digit month without leading zero (e.g., 7)

## Time Rounding for joy-deploy

For URLs containing `joy-deploy/free-proxy-list`, hours are rounded to the nearest 4-hour increment:
- 00:00-02:59 → 00:00
- 03:00-08:59 → 06:00
- 09:00-14:59 → 12:00
- 15:00-20:59 → 18:00
- 21:00-23:59 → 00:00 (next day)

This matches the actual file structure used by the joy-deploy repository.

## Summary by Sourcery

Enable dynamic URL generation by resolving datetime tokens in proxy source URLs, with special rounding logic for joy-deploy endpoints

New Features:
- Introduce replaceDateTimeTokens to substitute {YYYY}, {MM}, {DD}, {HH}, {mm}, and {M} tokens with current date/time values
- Implement roundToNearestJoyDeployHour to align joy-deploy timestamps to the nearest 4-hour increment

Enhancements:
- Apply date/time token replacement in the URL parsing logic in load.go