### PR TITLE
feat: add scheme length validation to prevent invalid protocols

### DIFF
--- a/internal/parser.go
+++ b/internal/parser.go
@@ -18,6 +18,13 @@ var (
 	ErrInvalidProxy = errors.New("gfp: invalid proxy")
 )
 
+const (
+	// MaxSchemeLength defines the maximum allowed length for proxy scheme.
+	// Legitimate proxy protocols (http, https, socks4, socks5, vmess, trojan, vless, ss, ssr, hy, hy2)
+	// are all 6 characters or less. 15 provides safe headroom for future protocols.
+	MaxSchemeLength = 15
+)
+
 type Parser func(string, string) (*Proxy, error)
 
 func RegisterParser(name string, parser Parser) {
@@ -50,7 +57,7 @@ func ParseProxyURL(proto, proxyURL string) (*Proxy, error) {
 	scheme := strings.ToLower(u.Scheme)
 
 	// Validate scheme length to prevent invalid protocols
-	if len(scheme) == 0 || len(scheme) > 15 {
+	if len(scheme) == 0 || len(scheme) > MaxSchemeLength {
 		return nil, ErrInvalidProxy
 	}
 
@@ -150,7 +157,6 @@ func ParseProxyURL(proto, proxyURL string) (*Proxy, error) {
 		it.Port = port
 		it.Opaque = strings.TrimPrefix(vu.Raw().String(), "ssr://")
 	default: // "http", "https", "socks4", "socks4a", "socks5", "socks5h":
-
 		it = &Proxy{
 			IP:   u.Hostname(),
 			User: u.User.Username(),


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Reject proxy URLs with empty or excessively long schemes to prevent invalid or malformed protocols from being parsed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject proxy URLs with scheme lengths exceeding limits, preventing invalid configuration errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->