### PR TITLE
Add Clash config parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/cnlangzi/proxyclient v0.0.23
 	github.com/stretchr/testify v1.11.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -50,7 +51,6 @@ require (
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gvisor.dev/gvisor v0.0.0-20250428193742-2d800c3129d5 // indirect
 	h12.io/socks v1.0.3 // indirect
 	lukechampine.com/blake3 v1.4.1 // indirect

--- a/internal/transformer.go
+++ b/internal/transformer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strconv"
+
 	"gopkg.in/yaml.v3"
 )
 
@@ -44,12 +45,53 @@ func FromBase64(buf []byte) []byte {
 	return decoded
 }
 
-// ClashConfig represents a Clash YAML configuration
-type ClashConfig struct {
-	Proxies []map[string]interface{} `yaml:"proxies"`
+// FlexPort handles YAML port values that may be int, float, or string.
+type FlexPort int
+
+func (p *FlexPort) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Tag {
+	case "!!int":
+		v, err := strconv.Atoi(value.Value)
+		if err != nil {
+			return err
+		}
+		*p = FlexPort(v)
+		return nil
+	case "!!float":
+		v, err := strconv.ParseFloat(value.Value, 64)
+		if err != nil {
+			return err
+		}
+		*p = FlexPort(int(v))
+		return nil
+	case "!!str":
+		v, err := strconv.Atoi(value.Value)
+		if err != nil {
+			return err
+		}
+		*p = FlexPort(v)
+		return nil
+	}
+	// Unsupported types (bool, null, etc.) default to 0; port range check rejects them.
+	return nil
 }
 
-// FromClash parses a Clash YAML config and extracts proxy URLs
+// ClashProxy represents a single proxy entry in a Clash config.
+type ClashProxy struct {
+	Type     string   `yaml:"type"`
+	Server   string   `yaml:"server"`
+	Port     FlexPort `yaml:"port"`
+	Cipher   string   `yaml:"cipher,omitempty"`
+	Password string   `yaml:"password,omitempty"`
+	Username string   `yaml:"username,omitempty"`
+}
+
+// ClashConfig represents a Clash YAML configuration.
+type ClashConfig struct {
+	Proxies []ClashProxy `yaml:"proxies"`
+}
+
+// FromClash parses a Clash YAML config and extracts proxy URLs.
 func FromClash(buf []byte) []byte {
 	// Limit YAML size to prevent OOM attacks (10MB max)
 	const maxYAMLSize = 10 * 1024 * 1024
@@ -74,52 +116,31 @@ func FromClash(buf []byte) []byte {
 	return result.Bytes()
 }
 
-func buildProxyURL(proxy map[string]interface{}) string {
-	proxyType, ok := proxy["type"].(string)
-	if !ok {
+func buildProxyURL(proxy ClashProxy) string {
+	if proxy.Type == "" || proxy.Server == "" {
 		return ""
 	}
 
-	server, ok := proxy["server"].(string)
-	if !ok {
-		return ""
-	}
-
-	port, ok := proxy["port"]
-	if !ok {
-		return ""
-	}
-
-	portInt, err := extractPort(port)
-	if err != nil {
-		return ""
-	}
+	port := int(proxy.Port)
 
 	// Validate port range
-	if portInt < 1 || portInt > 65535 {
+	if port < 1 || port > 65535 {
 		return ""
 	}
 
-	switch proxyType {
+	switch proxy.Type {
 	case "http", "https", "socks5", "socks4":
-		username, hasUser := proxy["username"].(string)
-		password, hasPass := proxy["password"].(string)
-		if hasUser && hasPass && username != "" && password != "" {
-			return fmt.Sprintf("%s://%s:%s@%s:%d", proxyType, username, password, server, portInt)
+		if proxy.Username != "" && proxy.Password != "" {
+			return fmt.Sprintf("%s://%s:%s@%s:%d", proxy.Type, proxy.Username, proxy.Password, proxy.Server, port)
 		}
-		return fmt.Sprintf("%s://%s:%d", proxyType, server, portInt)
+		return fmt.Sprintf("%s://%s:%d", proxy.Type, proxy.Server, port)
 	case "ss":
-		cipher, ok := proxy["cipher"].(string)
-		if !ok || cipher == "" {
-			return ""
-		}
-		password, ok := proxy["password"].(string)
-		if !ok || password == "" {
+		if proxy.Cipher == "" || proxy.Password == "" {
 			return ""
 		}
 		// Shadowsocks URL format: ss://base64(cipher:password)@server:port
-		credentials := base64.StdEncoding.EncodeToString([]byte(cipher + ":" + password))
-		return fmt.Sprintf("ss://%s@%s:%d", credentials, server, portInt)
+		credentials := base64.StdEncoding.EncodeToString([]byte(proxy.Cipher + ":" + proxy.Password))
+		return fmt.Sprintf("ss://%s@%s:%d", credentials, proxy.Server, port)
 	case "vmess", "vless", "trojan":
 		// These protocols require complex URL formats with UUIDs, encryption params, etc.
 		// Since we can't construct valid URLs without all required fields, skip them
@@ -127,22 +148,5 @@ func buildProxyURL(proxy map[string]interface{}) string {
 		return ""
 	default:
 		return ""
-	}
-}
-
-func extractPort(port interface{}) (int, error) {
-	switch v := port.(type) {
-	case int:
-		return v, nil
-	case float64:
-		return int(v), nil
-	case string:
-		p, err := strconv.Atoi(v)
-		if err != nil {
-			return 0, err
-		}
-		return p, nil
-	default:
-		return 0, fmt.Errorf("unsupported port type")
 	}
 }

--- a/internal/transformer.go
+++ b/internal/transformer.go
@@ -102,6 +102,11 @@ func buildProxyURL(proxy map[string]interface{}) string {
 
 	switch proxyType {
 	case "http", "https", "socks5", "socks4":
+		username, hasUser := proxy["username"].(string)
+		password, hasPass := proxy["password"].(string)
+		if hasUser && hasPass && username != "" && password != "" {
+			return fmt.Sprintf("%s://%s:%s@%s:%d", proxyType, username, password, server, portInt)
+		}
 		return fmt.Sprintf("%s://%s:%d", proxyType, server, portInt)
 	case "ss":
 		cipher, ok := proxy["cipher"].(string)
@@ -113,7 +118,7 @@ func buildProxyURL(proxy map[string]interface{}) string {
 			return ""
 		}
 		// Shadowsocks URL format: ss://base64(cipher:password)@server:port
-		credentials := base64.URLEncoding.EncodeToString([]byte(cipher + ":" + password))
+		credentials := base64.StdEncoding.EncodeToString([]byte(cipher + ":" + password))
 		return fmt.Sprintf("ss://%s@%s:%d", credentials, server, portInt)
 	case "vmess", "vless", "trojan":
 		// These protocols require complex URL formats with UUIDs, encryption params, etc.

--- a/internal/transformer.go
+++ b/internal/transformer.go
@@ -1,6 +1,11 @@
 package internal
 
-import "encoding/base64"
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"gopkg.in/yaml.v3"
+)
 
 var (
 	Transformers = map[string]Transformer{}
@@ -8,6 +13,7 @@ var (
 
 func init() {
 	Transformers["base64"] = FromBase64
+	Transformers["clash"] = FromClash
 }
 
 type Transformer func([]byte) []byte
@@ -35,4 +41,73 @@ func FromBase64(buf []byte) []byte {
 	}
 
 	return decoded
+}
+
+// ClashConfig represents a Clash YAML configuration
+type ClashConfig struct {
+	Proxies []map[string]interface{} `yaml:"proxies"`
+}
+
+// FromClash parses a Clash YAML config and extracts proxy URLs
+func FromClash(buf []byte) []byte {
+	var config ClashConfig
+	if err := yaml.Unmarshal(buf, &config); err != nil {
+		return []byte{}
+	}
+
+	var result bytes.Buffer
+	for _, proxy := range config.Proxies {
+		proxyURL := buildProxyURL(proxy)
+		if proxyURL != "" {
+			result.WriteString(proxyURL)
+			result.WriteString("\n")
+		}
+	}
+
+	return result.Bytes()
+}
+
+func buildProxyURL(proxy map[string]interface{}) string {
+	proxyType, ok := proxy["type"].(string)
+	if !ok {
+		return ""
+	}
+
+	server, ok := proxy["server"].(string)
+	if !ok {
+		return ""
+	}
+
+	port, ok := proxy["port"]
+	if !ok {
+		return ""
+	}
+
+	var portInt int
+	switch v := port.(type) {
+	case int:
+		portInt = v
+	case float64:
+		portInt = int(v)
+	default:
+		return ""
+	}
+
+	switch proxyType {
+	case "http", "https", "socks5", "socks4":
+		return fmt.Sprintf("%s://%s:%d", proxyType, server, portInt)
+	case "ss":
+		cipher, _ := proxy["cipher"].(string)
+		password, _ := proxy["password"].(string)
+		if cipher == "" || password == "" {
+			return ""
+		}
+		return fmt.Sprintf("ss://%s:%s@%s:%d", cipher, password, server, portInt)
+	case "vmess", "vless", "trojan":
+		// For complex protocols, we would need to construct the full URL
+		// For now, return a basic format
+		return fmt.Sprintf("%s://%s:%d", proxyType, server, portInt)
+	default:
+		return ""
+	}
 }

--- a/internal/transformer.go
+++ b/internal/transformer.go
@@ -3,8 +3,12 @@ package internal
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"net"
+	"net/url"
 	"strconv"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -62,6 +66,10 @@ func (p *FlexPort) UnmarshalYAML(value *yaml.Node) error {
 		if err != nil {
 			return err
 		}
+		// Reject non-integer floats like 8080.9
+		if v != float64(int(v)) {
+			return fmt.Errorf("port must be an integer, got %v", v)
+		}
 		*p = FlexPort(int(v))
 		return nil
 	case "!!str":
@@ -76,14 +84,55 @@ func (p *FlexPort) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
+// ClashWSHeaders represents WebSocket headers in Clash config.
+type ClashWSHeaders struct {
+	Host string `yaml:"Host,omitempty"`
+}
+
+// ClashWSOpts represents WebSocket transport options.
+type ClashWSOpts struct {
+	Path    string         `yaml:"path,omitempty"`
+	Headers ClashWSHeaders `yaml:"headers,omitempty"`
+}
+
+// ClashGRPCOpts represents gRPC transport options.
+type ClashGRPCOpts struct {
+	ServiceName string `yaml:"grpc-service-name,omitempty"`
+}
+
+// ClashH2Opts represents HTTP/2 transport options.
+type ClashH2Opts struct {
+	Path string   `yaml:"path,omitempty"`
+	Host []string `yaml:"host,omitempty"`
+}
+
+// ClashRealityOpts represents Reality TLS options.
+type ClashRealityOpts struct {
+	PublicKey string `yaml:"public-key,omitempty"`
+	ShortID   string `yaml:"short-id,omitempty"`
+}
+
 // ClashProxy represents a single proxy entry in a Clash config.
 type ClashProxy struct {
-	Type     string   `yaml:"type"`
-	Server   string   `yaml:"server"`
-	Port     FlexPort `yaml:"port"`
-	Cipher   string   `yaml:"cipher,omitempty"`
-	Password string   `yaml:"password,omitempty"`
-	Username string   `yaml:"username,omitempty"`
+	Name              string            `yaml:"name,omitempty"`
+	Type              string            `yaml:"type"`
+	Server            string            `yaml:"server"`
+	Port              FlexPort          `yaml:"port"`
+	Cipher            string            `yaml:"cipher,omitempty"`
+	Password          string            `yaml:"password,omitempty"`
+	Username          string            `yaml:"username,omitempty"`
+	UUID              string            `yaml:"uuid,omitempty"`
+	AlterID           int               `yaml:"alterId,omitempty"`
+	Network           string            `yaml:"network,omitempty"`
+	TLS               bool              `yaml:"tls,omitempty"`
+	ServerName        string            `yaml:"servername,omitempty"`
+	SNI               string            `yaml:"sni,omitempty"`
+	Flow              string            `yaml:"flow,omitempty"`
+	ClientFingerprint string            `yaml:"client-fingerprint,omitempty"`
+	WSOpts            *ClashWSOpts      `yaml:"ws-opts,omitempty"`
+	GRPCOpts          *ClashGRPCOpts    `yaml:"grpc-opts,omitempty"`
+	H2Opts            *ClashH2Opts      `yaml:"h2-opts,omitempty"`
+	RealityOpts       *ClashRealityOpts `yaml:"reality-opts,omitempty"`
 }
 
 // ClashConfig represents a Clash YAML configuration.
@@ -116,8 +165,13 @@ func FromClash(buf []byte) []byte {
 	return result.Bytes()
 }
 
+// hostPort formats server:port, handling IPv6 addresses correctly via net.JoinHostPort.
+func hostPort(server string, port int) string {
+	return net.JoinHostPort(server, strconv.Itoa(port))
+}
+
 func buildProxyURL(proxy ClashProxy) string {
-	if proxy.Type == "" || proxy.Server == "" {
+	if proxy.Type == "" || strings.TrimSpace(proxy.Server) == "" {
 		return ""
 	}
 
@@ -130,23 +184,267 @@ func buildProxyURL(proxy ClashProxy) string {
 
 	switch proxy.Type {
 	case "http", "https", "socks5", "socks4":
-		if proxy.Username != "" && proxy.Password != "" {
-			return fmt.Sprintf("%s://%s:%s@%s:%d", proxy.Type, proxy.Username, proxy.Password, proxy.Server, port)
+		u := &url.URL{
+			Scheme: proxy.Type,
+			Host:   hostPort(proxy.Server, port),
 		}
-		return fmt.Sprintf("%s://%s:%d", proxy.Type, proxy.Server, port)
+		if proxy.Username != "" {
+			if proxy.Password != "" {
+				u.User = url.UserPassword(proxy.Username, proxy.Password)
+			} else {
+				u.User = url.User(proxy.Username)
+			}
+		}
+		return u.String()
 	case "ss":
 		if proxy.Cipher == "" || proxy.Password == "" {
 			return ""
 		}
 		// Shadowsocks URL format: ss://base64(cipher:password)@server:port
+		// Uses standard base64 (RFC 4648) per SIP008 spec.
 		credentials := base64.StdEncoding.EncodeToString([]byte(proxy.Cipher + ":" + proxy.Password))
-		return fmt.Sprintf("ss://%s@%s:%d", credentials, proxy.Server, port)
-	case "vmess", "vless", "trojan":
-		// These protocols require complex URL formats with UUIDs, encryption params, etc.
-		// Since we can't construct valid URLs without all required fields, skip them
-		// to avoid creating broken proxy entries
-		return ""
+		return fmt.Sprintf("ss://%s@%s", credentials, hostPort(proxy.Server, port))
+	case "vmess":
+		return buildVmessURL(proxy)
+	case "vless":
+		return buildVlessURL(proxy)
+	case "trojan":
+		return buildTrojanURL(proxy)
 	default:
 		return ""
 	}
+}
+
+// buildVmessURL constructs a vmess:// URL from Clash YAML proxy fields.
+// Format: vmess://base64(JSON) matching proxyclient VmessConfig struct.
+func buildVmessURL(proxy ClashProxy) string {
+	if proxy.UUID == "" {
+		return ""
+	}
+
+	network := proxy.Network
+	if network == "" {
+		network = "tcp"
+	}
+
+	config := map[string]interface{}{
+		"v":    "2",
+		"ps":   proxy.Name,
+		"add":  proxy.Server,
+		"port": int(proxy.Port),
+		"id":   proxy.UUID,
+		"aid":  proxy.AlterID,
+		"net":  network,
+		"type": "none",
+		"host": "",
+		"path": "",
+		"tls":  "",
+	}
+
+	if proxy.TLS {
+		config["tls"] = "tls"
+	}
+	if proxy.SNI != "" {
+		config["sni"] = proxy.SNI
+	} else if proxy.ServerName != "" {
+		config["sni"] = proxy.ServerName
+	}
+	if proxy.Cipher != "" {
+		config["security"] = proxy.Cipher
+	}
+	if proxy.ClientFingerprint != "" {
+		config["fp"] = proxy.ClientFingerprint
+	}
+
+	// Transport-specific settings
+	switch network {
+	case "ws":
+		if proxy.WSOpts != nil {
+			if proxy.WSOpts.Path != "" {
+				config["path"] = proxy.WSOpts.Path
+			}
+			if proxy.WSOpts.Headers.Host != "" {
+				config["host"] = proxy.WSOpts.Headers.Host
+			}
+		}
+	case "grpc":
+		if proxy.GRPCOpts != nil && proxy.GRPCOpts.ServiceName != "" {
+			config["path"] = proxy.GRPCOpts.ServiceName
+		}
+	case "h2":
+		if proxy.H2Opts != nil {
+			if proxy.H2Opts.Path != "" {
+				config["path"] = proxy.H2Opts.Path
+			}
+			if len(proxy.H2Opts.Host) > 0 {
+				config["host"] = proxy.H2Opts.Host[0]
+			}
+		}
+	}
+
+	jsonBytes, err := json.Marshal(config)
+	if err != nil {
+		return ""
+	}
+
+	encoded := base64.StdEncoding.EncodeToString(jsonBytes)
+	return "vmess://" + encoded
+}
+
+// buildVlessURL constructs a vless:// URL from Clash YAML proxy fields.
+// Format: vless://uuid@host:port?encryption=none&type=tcp&security=tls&...#name
+// Matches proxyclient ParseVlessURL expected format.
+func buildVlessURL(proxy ClashProxy) string {
+	if proxy.UUID == "" {
+		return ""
+	}
+
+	hp := hostPort(proxy.Server, int(proxy.Port))
+
+	params := url.Values{}
+	params.Set("encryption", "none")
+
+	network := proxy.Network
+	if network == "" {
+		network = "tcp"
+	}
+	params.Set("type", network)
+
+	if proxy.TLS {
+		params.Set("security", "tls")
+	}
+	if proxy.SNI != "" {
+		params.Set("sni", proxy.SNI)
+	} else if proxy.ServerName != "" {
+		params.Set("sni", proxy.ServerName)
+	}
+	if proxy.Flow != "" {
+		params.Set("flow", proxy.Flow)
+	}
+	if proxy.ClientFingerprint != "" {
+		params.Set("fp", proxy.ClientFingerprint)
+	}
+
+	switch network {
+	case "ws":
+		if proxy.WSOpts != nil {
+			if proxy.WSOpts.Path != "" {
+				params.Set("path", proxy.WSOpts.Path)
+			}
+			if proxy.WSOpts.Headers.Host != "" {
+				params.Set("host", proxy.WSOpts.Headers.Host)
+			}
+		}
+	case "grpc":
+		if proxy.GRPCOpts != nil && proxy.GRPCOpts.ServiceName != "" {
+			params.Set("serviceName", proxy.GRPCOpts.ServiceName)
+		}
+	case "h2":
+		if proxy.H2Opts != nil {
+			if proxy.H2Opts.Path != "" {
+				params.Set("path", proxy.H2Opts.Path)
+			}
+			if len(proxy.H2Opts.Host) > 0 {
+				params.Set("host", proxy.H2Opts.Host[0])
+			}
+		}
+	}
+
+	// Reality overrides TLS security
+	if proxy.RealityOpts != nil {
+		params.Set("security", "reality")
+		if proxy.RealityOpts.PublicKey != "" {
+			params.Set("pbk", proxy.RealityOpts.PublicKey)
+		}
+		if proxy.RealityOpts.ShortID != "" {
+			params.Set("sid", proxy.RealityOpts.ShortID)
+		}
+	}
+
+	u := &url.URL{
+		Scheme:   "vless",
+		User:     url.User(proxy.UUID),
+		Host:     hp,
+		RawQuery: params.Encode(),
+		Fragment: proxy.Name,
+	}
+
+	return u.String()
+}
+
+// buildTrojanURL constructs a trojan:// URL from Clash YAML proxy fields.
+// Format: trojan://password@host:port?security=tls&type=tcp&...#name
+// Matches proxyclient ParseTrojanURL expected format.
+func buildTrojanURL(proxy ClashProxy) string {
+	if proxy.Password == "" {
+		return ""
+	}
+
+	hp := hostPort(proxy.Server, int(proxy.Port))
+
+	params := url.Values{}
+
+	network := proxy.Network
+	if network == "" {
+		network = "tcp"
+	}
+	params.Set("type", network)
+
+	// Trojan checks both "sni" and "servername" in Clash configs
+	if proxy.SNI != "" {
+		params.Set("sni", proxy.SNI)
+	} else if proxy.ServerName != "" {
+		params.Set("sni", proxy.ServerName)
+	}
+	if proxy.ClientFingerprint != "" {
+		params.Set("fp", proxy.ClientFingerprint)
+	}
+
+	switch network {
+	case "ws":
+		if proxy.WSOpts != nil {
+			if proxy.WSOpts.Path != "" {
+				params.Set("path", proxy.WSOpts.Path)
+			}
+			if proxy.WSOpts.Headers.Host != "" {
+				params.Set("host", proxy.WSOpts.Headers.Host)
+			}
+		}
+	case "grpc":
+		if proxy.GRPCOpts != nil && proxy.GRPCOpts.ServiceName != "" {
+			params.Set("serviceName", proxy.GRPCOpts.ServiceName)
+		}
+	case "h2":
+		if proxy.H2Opts != nil {
+			if proxy.H2Opts.Path != "" {
+				params.Set("path", proxy.H2Opts.Path)
+			}
+			if len(proxy.H2Opts.Host) > 0 {
+				params.Set("host", proxy.H2Opts.Host[0])
+			}
+		}
+	}
+
+	// Reality overrides default TLS security
+	if proxy.RealityOpts != nil {
+		params.Set("security", "reality")
+		if proxy.RealityOpts.PublicKey != "" {
+			params.Set("pbk", proxy.RealityOpts.PublicKey)
+		}
+		if proxy.RealityOpts.ShortID != "" {
+			params.Set("sid", proxy.RealityOpts.ShortID)
+		}
+	} else {
+		params.Set("security", "tls")
+	}
+
+	u := &url.URL{
+		Scheme:   "trojan",
+		User:     url.User(proxy.Password),
+		Host:     hp,
+		RawQuery: params.Encode(),
+		Fragment: proxy.Name,
+	}
+
+	return u.String()
 }

--- a/internal/transformer.go
+++ b/internal/transformer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"strconv"
 	"gopkg.in/yaml.v3"
 )
 
@@ -50,6 +51,12 @@ type ClashConfig struct {
 
 // FromClash parses a Clash YAML config and extracts proxy URLs
 func FromClash(buf []byte) []byte {
+	// Limit YAML size to prevent OOM attacks (10MB max)
+	const maxYAMLSize = 10 * 1024 * 1024
+	if len(buf) > maxYAMLSize {
+		return []byte{}
+	}
+
 	var config ClashConfig
 	if err := yaml.Unmarshal(buf, &config); err != nil {
 		return []byte{}
@@ -83,13 +90,13 @@ func buildProxyURL(proxy map[string]interface{}) string {
 		return ""
 	}
 
-	var portInt int
-	switch v := port.(type) {
-	case int:
-		portInt = v
-	case float64:
-		portInt = int(v)
-	default:
+	portInt, err := extractPort(port)
+	if err != nil {
+		return ""
+	}
+
+	// Validate port range
+	if portInt < 1 || portInt > 65535 {
 		return ""
 	}
 
@@ -97,17 +104,40 @@ func buildProxyURL(proxy map[string]interface{}) string {
 	case "http", "https", "socks5", "socks4":
 		return fmt.Sprintf("%s://%s:%d", proxyType, server, portInt)
 	case "ss":
-		cipher, _ := proxy["cipher"].(string)
-		password, _ := proxy["password"].(string)
-		if cipher == "" || password == "" {
+		cipher, ok := proxy["cipher"].(string)
+		if !ok || cipher == "" {
 			return ""
 		}
-		return fmt.Sprintf("ss://%s:%s@%s:%d", cipher, password, server, portInt)
+		password, ok := proxy["password"].(string)
+		if !ok || password == "" {
+			return ""
+		}
+		// Shadowsocks URL format: ss://base64(cipher:password)@server:port
+		credentials := base64.URLEncoding.EncodeToString([]byte(cipher + ":" + password))
+		return fmt.Sprintf("ss://%s@%s:%d", credentials, server, portInt)
 	case "vmess", "vless", "trojan":
-		// For complex protocols, we would need to construct the full URL
-		// For now, return a basic format
-		return fmt.Sprintf("%s://%s:%d", proxyType, server, portInt)
+		// These protocols require complex URL formats with UUIDs, encryption params, etc.
+		// Since we can't construct valid URLs without all required fields, skip them
+		// to avoid creating broken proxy entries
+		return ""
 	default:
 		return ""
+	}
+}
+
+func extractPort(port interface{}) (int, error) {
+	switch v := port.(type) {
+	case int:
+		return v, nil
+	case float64:
+		return int(v), nil
+	case string:
+		p, err := strconv.Atoi(v)
+		if err != nil {
+			return 0, err
+		}
+		return p, nil
+	default:
+		return 0, fmt.Errorf("unsupported port type")
 	}
 }

--- a/internal/transformer.go
+++ b/internal/transformer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net"
 	"net/url"
 	"strconv"
@@ -66,9 +67,18 @@ func (p *FlexPort) UnmarshalYAML(value *yaml.Node) error {
 		if err != nil {
 			return err
 		}
-		// Reject non-integer floats like 8080.9
-		if v != float64(int(v)) {
+		// Reject NaN, Inf, non-integer floats, and out-of-range values before
+		// casting. int(f) on NaN/Inf is implementation-defined and silently
+		// truncates fractional parts (8080.9 -> 8080), so each case is checked
+		// explicitly before the cast.
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return fmt.Errorf("port must be a finite number, got %v", v)
+		}
+		if v != math.Trunc(v) {
 			return fmt.Errorf("port must be an integer, got %v", v)
+		}
+		if v < 1 || v > 65535 {
+			return fmt.Errorf("port must be in range [1, 65535], got %v", v)
 		}
 		*p = FlexPort(int(v))
 		return nil

--- a/internal/transformer_test.go
+++ b/internal/transformer_test.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"encoding/base64"
+	"strings"
 	"testing"
 )
 
@@ -41,7 +43,7 @@ func TestFromClash(t *testing.T) {
     port: 443
     cipher: chacha20-ietf-poly1305
     password: "test123"`,
-			expected: "ss://chacha20-ietf-poly1305:test123@9.10.11.12:443\n",
+			expected: "ss://" + base64.URLEncoding.EncodeToString([]byte("chacha20-ietf-poly1305:test123")) + "@9.10.11.12:443\n",
 		},
 		{
 			name: "clash config with no proxies",
@@ -52,6 +54,117 @@ socks-port: 7891`,
 		{
 			name: "empty input",
 			input: "",
+			expected: "",
+		},
+		{
+			name: "invalid YAML",
+			input: `proxies:
+  - name: "test"
+    type: http
+    server: 1.2.3.4
+    port: invalid syntax {{{`,
+			expected: "",
+		},
+		{
+			name: "port as string",
+			input: `proxies:
+  - name: "http-proxy"
+    type: http
+    server: 1.2.3.4
+    port: "8080"`,
+			expected: "http://1.2.3.4:8080\n",
+		},
+		{
+			name: "missing server field",
+			input: `proxies:
+  - name: "http-proxy"
+    type: http
+    port: 8080`,
+			expected: "",
+		},
+		{
+			name: "missing port field",
+			input: `proxies:
+  - name: "http-proxy"
+    type: http
+    server: 1.2.3.4`,
+			expected: "",
+		},
+		{
+			name: "missing type field",
+			input: `proxies:
+  - name: "http-proxy"
+    server: 1.2.3.4
+    port: 8080`,
+			expected: "",
+		},
+		{
+			name: "port out of range high",
+			input: `proxies:
+  - name: "http-proxy"
+    type: http
+    server: 1.2.3.4
+    port: 99999`,
+			expected: "",
+		},
+		{
+			name: "port out of range low",
+			input: `proxies:
+  - name: "http-proxy"
+    type: http
+    server: 1.2.3.4
+    port: 0`,
+			expected: "",
+		},
+		{
+			name: "ss proxy missing cipher",
+			input: `proxies:
+  - name: "ss-proxy"
+    type: ss
+    server: 1.2.3.4
+    port: 443
+    password: "test123"`,
+			expected: "",
+		},
+		{
+			name: "ss proxy missing password",
+			input: `proxies:
+  - name: "ss-proxy"
+    type: ss
+    server: 1.2.3.4
+    port: 443
+    cipher: chacha20-ietf-poly1305`,
+			expected: "",
+		},
+		{
+			name: "vmess proxy skipped",
+			input: `proxies:
+  - name: "vmess-proxy"
+    type: vmess
+    server: 1.2.3.4
+    port: 443`,
+			expected: "",
+		},
+		{
+			name: "mixed valid and invalid proxies",
+			input: `proxies:
+  - name: "valid"
+    type: http
+    server: 1.2.3.4
+    port: 8080
+  - name: "invalid"
+    type: http
+    server: 5.6.7.8
+    port: 99999
+  - name: "valid2"
+    type: socks5
+    server: 9.10.11.12
+    port: 1080`,
+			expected: "http://1.2.3.4:8080\nsocks5://9.10.11.12:1080\n",
+		},
+		{
+			name: "oversized YAML rejected",
+			input: strings.Repeat("x", 11*1024*1024), // 11MB
 			expected: "",
 		},
 	}

--- a/internal/transformer_test.go
+++ b/internal/transformer_test.go
@@ -1,0 +1,67 @@
+package internal
+
+import (
+	"testing"
+)
+
+func TestFromClash(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name: "basic clash config with http proxy",
+			input: `proxies:
+  - name: "http-proxy"
+    type: http
+    server: 1.2.3.4
+    port: 8080`,
+			expected: "http://1.2.3.4:8080\n",
+		},
+		{
+			name: "clash config with multiple proxies",
+			input: `proxies:
+  - name: "http-proxy"
+    type: http
+    server: 1.2.3.4
+    port: 8080
+  - name: "socks5-proxy"
+    type: socks5
+    server: 5.6.7.8
+    port: 1080`,
+			expected: "http://1.2.3.4:8080\nsocks5://5.6.7.8:1080\n",
+		},
+		{
+			name: "clash config with ss proxy",
+			input: `proxies:
+  - name: "ss-proxy"
+    type: ss
+    server: 9.10.11.12
+    port: 443
+    cipher: chacha20-ietf-poly1305
+    password: "test123"`,
+			expected: "ss://chacha20-ietf-poly1305:test123@9.10.11.12:443\n",
+		},
+		{
+			name: "clash config with no proxies",
+			input: `port: 7890
+socks-port: 7891`,
+			expected: "",
+		},
+		{
+			name: "empty input",
+			input: "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := string(FromClash([]byte(tt.input)))
+			if result != tt.expected {
+				t.Errorf("FromClash() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/transformer_test.go
+++ b/internal/transformer_test.go
@@ -2,6 +2,8 @@ package internal
 
 import (
 	"encoding/base64"
+	"encoding/json"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -166,12 +168,53 @@ socks-port: 7891`,
 			expected: "http://user1:pass1@1.2.3.4:8080\n",
 		},
 		{
-			name: "vmess proxy skipped",
+			name: "http proxy with special chars in auth",
 			input: `proxies:
-  - name: "vmess-proxy"
-    type: vmess
+  - name: "auth-proxy"
+    type: http
     server: 1.2.3.4
-    port: 443`,
+    port: 8080
+    username: "user1"
+    password: "p@ss"`,
+			expected: "http://user1:p%40ss@1.2.3.4:8080\n",
+		},
+		{
+			name: "http proxy with username only",
+			input: `proxies:
+  - name: "auth-proxy"
+    type: http
+    server: 1.2.3.4
+    port: 8080
+    username: "user1"`,
+			expected: "http://user1@1.2.3.4:8080\n",
+		},
+		{
+			name: "http proxy with space in password",
+			input: `proxies:
+  - name: "space-pass"
+    type: http
+    server: 1.2.3.4
+    port: 8080
+    username: "user1"
+    password: "foo bar"`,
+			expected: "http://user1:foo%20bar@1.2.3.4:8080\n",
+		},
+		{
+			name: "empty server rejected",
+			input: `proxies:
+  - name: "empty-server"
+    type: http
+    server: ""
+    port: 8080`,
+			expected: "",
+		},
+		{
+			name: "whitespace server rejected",
+			input: `proxies:
+  - name: "space-server"
+    type: http
+    server: "  "
+    port: 8080`,
 			expected: "",
 		},
 		{
@@ -182,6 +225,15 @@ socks-port: 7891`,
     server: 1.2.3.4
     port: 8080.0`,
 			expected: "http://1.2.3.4:8080\n",
+		},
+		{
+			name: "non-integer float port rejected",
+			input: `proxies:
+  - name: "float-port"
+    type: http
+    server: 1.2.3.4
+    port: 8080.9`,
+			expected: "",
 		},
 		{
 			name: "bool port skipped gracefully",
@@ -218,6 +270,20 @@ socks-port: 7891`,
 			expected: "http://1.2.3.4:8080\nsocks5://9.10.11.12:1080\n",
 		},
 		{
+			name: "IPv6 server",
+			input: `proxies:
+  - name: "ipv6"
+    type: http
+    server: "::1"
+    port: 8080`,
+			expected: "http://[::1]:8080\n",
+		},
+		{
+			name: "exact 10MB YAML accepted",
+			input: strings.Repeat("x", 10*1024*1024),
+			expected: "",
+		},
+		{
 			name: "oversized YAML rejected",
 			input: strings.Repeat("x", 11*1024*1024), // 11MB
 			expected: "",
@@ -232,4 +298,695 @@ socks-port: 7891`,
 			}
 		})
 	}
+}
+
+func TestVmessURL(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name: "basic vmess",
+			input: `proxies:
+  - name: "vmess-test"
+    type: vmess
+    server: example.com
+    port: 443
+    uuid: "75a0885f-0ca5-42a4-8651-391cf8193154"
+    alterId: 0
+    cipher: auto
+    tls: true`,
+		},
+		{
+			name: "vmess with ws transport",
+			input: `proxies:
+  - name: "vmess-ws"
+    type: vmess
+    server: ws.example.com
+    port: 2096
+    uuid: "75a0885f-0ca5-42a4-8651-391cf8193154"
+    alterId: 0
+    cipher: auto
+    network: ws
+    tls: true
+    servername: ws.example.com
+    ws-opts:
+      path: /path
+      headers:
+        Host: ws.example.com`,
+		},
+		{
+			name: "vmess with grpc transport",
+			input: `proxies:
+  - name: "vmess-grpc"
+    type: vmess
+    server: grpc.example.com
+    port: 443
+    uuid: "75a0885f-0ca5-42a4-8651-391cf8193154"
+    alterId: 0
+    network: grpc
+    tls: true
+    grpc-opts:
+      grpc-service-name: myservice`,
+		},
+		{
+			name: "vmess with h2 transport",
+			input: `proxies:
+  - name: "vmess-h2"
+    type: vmess
+    server: h2.example.com
+    port: 443
+    uuid: "75a0885f-0ca5-42a4-8651-391cf8193154"
+    alterId: 0
+    network: h2
+    tls: true
+    h2-opts:
+      path: /h2path
+      host:
+        - h2.example.com`,
+		},
+		{
+			name: "vmess missing uuid skipped",
+			input: `proxies:
+  - name: "vmess-no-uuid"
+    type: vmess
+    server: example.com
+    port: 443`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := string(FromClash([]byte(tt.input)))
+			if tt.name == "vmess missing uuid skipped" {
+				if result != "" {
+					t.Errorf("expected empty result for missing uuid, got %q", result)
+				}
+				return
+			}
+
+			if result == "" {
+				t.Fatal("expected non-empty vmess URL")
+			}
+
+			line := strings.TrimSpace(result)
+			if !strings.HasPrefix(line, "vmess://") {
+				t.Fatalf("expected vmess:// prefix, got %q", line)
+			}
+
+			// Decode and verify the JSON structure
+			encoded := strings.TrimPrefix(line, "vmess://")
+			decoded, err := base64.StdEncoding.DecodeString(encoded)
+			if err != nil {
+				t.Fatalf("base64 decode failed: %v", err)
+			}
+
+			var config map[string]interface{}
+			if err := json.Unmarshal(decoded, &config); err != nil {
+				t.Fatalf("JSON unmarshal failed: %v", err)
+			}
+
+			// Verify required fields per proxyclient VmessConfig
+			if config["v"] != "2" {
+				t.Errorf("expected v=2, got %v", config["v"])
+			}
+			if config["id"] != "75a0885f-0ca5-42a4-8651-391cf8193154" {
+				t.Errorf("expected uuid, got %v", config["id"])
+			}
+			if _, ok := config["add"]; !ok {
+				t.Error("missing 'add' field")
+			}
+			if _, ok := config["port"]; !ok {
+				t.Error("missing 'port' field")
+			}
+
+			// Check transport-specific fields
+			switch tt.name {
+			case "vmess with ws transport":
+				if config["net"] != "ws" {
+					t.Errorf("expected net=ws, got %v", config["net"])
+				}
+				if config["path"] != "/path" {
+					t.Errorf("expected path=/path, got %v", config["path"])
+				}
+				if config["host"] != "ws.example.com" {
+					t.Errorf("expected host=ws.example.com, got %v", config["host"])
+				}
+				if config["tls"] != "tls" {
+					t.Errorf("expected tls=tls, got %v", config["tls"])
+				}
+			case "vmess with grpc transport":
+				if config["net"] != "grpc" {
+					t.Errorf("expected net=grpc, got %v", config["net"])
+				}
+				if config["path"] != "myservice" {
+					t.Errorf("expected path=myservice, got %v", config["path"])
+				}
+			case "vmess with h2 transport":
+				if config["net"] != "h2" {
+					t.Errorf("expected net=h2, got %v", config["net"])
+				}
+				if config["path"] != "/h2path" {
+					t.Errorf("expected path=/h2path, got %v", config["path"])
+				}
+				if config["host"] != "h2.example.com" {
+					t.Errorf("expected host=h2.example.com, got %v", config["host"])
+				}
+			case "basic vmess":
+				if config["tls"] != "tls" {
+					t.Errorf("expected tls=tls, got %v", config["tls"])
+				}
+				if config["security"] != "auto" {
+					t.Errorf("expected security=auto, got %v", config["security"])
+				}
+			}
+		})
+	}
+}
+
+func TestVlessURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		checkURL func(t *testing.T, rawURL string)
+	}{
+		{
+			name: "basic vless",
+			input: `proxies:
+  - name: "vless-test"
+    type: vless
+    server: example.com
+    port: 443
+    uuid: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    tls: true
+    servername: example.com`,
+			checkURL: func(t *testing.T, rawURL string) {
+				u, err := parseVlessTestURL(rawURL)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if u.User.Username() != "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" {
+					t.Errorf("expected uuid in userinfo, got %s", u.User.Username())
+				}
+				if u.Host != "example.com:443" {
+					t.Errorf("expected example.com:443, got %s", u.Host)
+				}
+				q := u.Query()
+				if q.Get("encryption") != "none" {
+					t.Errorf("expected encryption=none, got %s", q.Get("encryption"))
+				}
+				if q.Get("security") != "tls" {
+					t.Errorf("expected security=tls, got %s", q.Get("security"))
+				}
+				if q.Get("sni") != "example.com" {
+					t.Errorf("expected sni=example.com, got %s", q.Get("sni"))
+				}
+			},
+		},
+		{
+			name: "vless with ws and flow",
+			input: `proxies:
+  - name: "vless-ws"
+    type: vless
+    server: ws.example.com
+    port: 443
+    uuid: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    tls: true
+    flow: xtls-rprx-vision
+    network: ws
+    ws-opts:
+      path: /vless
+      headers:
+        Host: cdn.example.com`,
+			checkURL: func(t *testing.T, rawURL string) {
+				u, err := parseVlessTestURL(rawURL)
+				if err != nil {
+					t.Fatal(err)
+				}
+				q := u.Query()
+				if q.Get("type") != "ws" {
+					t.Errorf("expected type=ws, got %s", q.Get("type"))
+				}
+				if q.Get("flow") != "xtls-rprx-vision" {
+					t.Errorf("expected flow, got %s", q.Get("flow"))
+				}
+				if q.Get("path") != "/vless" {
+					t.Errorf("expected path=/vless, got %s", q.Get("path"))
+				}
+				if q.Get("host") != "cdn.example.com" {
+					t.Errorf("expected host=cdn.example.com, got %s", q.Get("host"))
+				}
+			},
+		},
+		{
+			name: "vless with reality",
+			input: `proxies:
+  - name: "vless-reality"
+    type: vless
+    server: reality.example.com
+    port: 443
+    uuid: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    client-fingerprint: chrome
+    reality-opts:
+      public-key: abc123publickey
+      short-id: deadbeef`,
+			checkURL: func(t *testing.T, rawURL string) {
+				u, err := parseVlessTestURL(rawURL)
+				if err != nil {
+					t.Fatal(err)
+				}
+				q := u.Query()
+				if q.Get("security") != "reality" {
+					t.Errorf("expected security=reality, got %s", q.Get("security"))
+				}
+				if q.Get("pbk") != "abc123publickey" {
+					t.Errorf("expected pbk, got %s", q.Get("pbk"))
+				}
+				if q.Get("sid") != "deadbeef" {
+					t.Errorf("expected sid, got %s", q.Get("sid"))
+				}
+				if q.Get("fp") != "chrome" {
+					t.Errorf("expected fp=chrome, got %s", q.Get("fp"))
+				}
+			},
+		},
+		{
+			name: "vless with grpc",
+			input: `proxies:
+  - name: "vless-grpc"
+    type: vless
+    server: grpc.example.com
+    port: 443
+    uuid: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    tls: true
+    network: grpc
+    grpc-opts:
+      grpc-service-name: mygrpc`,
+			checkURL: func(t *testing.T, rawURL string) {
+				u, err := parseVlessTestURL(rawURL)
+				if err != nil {
+					t.Fatal(err)
+				}
+				q := u.Query()
+				if q.Get("type") != "grpc" {
+					t.Errorf("expected type=grpc, got %s", q.Get("type"))
+				}
+				if q.Get("serviceName") != "mygrpc" {
+					t.Errorf("expected serviceName=mygrpc, got %s", q.Get("serviceName"))
+				}
+			},
+		},
+		{
+			name: "vless with h2 transport",
+			input: `proxies:
+  - name: "vless-h2"
+    type: vless
+    server: h2.example.com
+    port: 443
+    uuid: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    tls: true
+    network: h2
+    h2-opts:
+      path: /h2path
+      host:
+        - h2.example.com`,
+			checkURL: func(t *testing.T, rawURL string) {
+				u, err := parseVlessTestURL(rawURL)
+				if err != nil {
+					t.Fatal(err)
+				}
+				q := u.Query()
+				if q.Get("type") != "h2" {
+					t.Errorf("expected type=h2, got %s", q.Get("type"))
+				}
+				if q.Get("path") != "/h2path" {
+					t.Errorf("expected path=/h2path, got %s", q.Get("path"))
+				}
+				if q.Get("host") != "h2.example.com" {
+					t.Errorf("expected host=h2.example.com, got %s", q.Get("host"))
+				}
+			},
+		},
+		{
+			name: "vless missing uuid skipped",
+			input: `proxies:
+  - name: "vless-no-uuid"
+    type: vless
+    server: example.com
+    port: 443`,
+			checkURL: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := string(FromClash([]byte(tt.input)))
+
+			if tt.checkURL == nil {
+				if result != "" {
+					t.Errorf("expected empty result, got %q", result)
+				}
+				return
+			}
+
+			line := strings.TrimSpace(result)
+			if !strings.HasPrefix(line, "vless://") {
+				t.Fatalf("expected vless:// prefix, got %q", line)
+			}
+			tt.checkURL(t, line)
+		})
+	}
+}
+
+func TestTrojanURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		checkURL func(t *testing.T, rawURL string)
+	}{
+		{
+			name: "basic trojan",
+			input: `proxies:
+  - name: "trojan-test"
+    type: trojan
+    server: trojan.example.com
+    port: 443
+    password: "mysecret"
+    sni: trojan.example.com`,
+			checkURL: func(t *testing.T, rawURL string) {
+				u, err := parseTrojanTestURL(rawURL)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if u.User.Username() != "mysecret" {
+					t.Errorf("expected password in userinfo, got %s", u.User.Username())
+				}
+				if u.Host != "trojan.example.com:443" {
+					t.Errorf("expected trojan.example.com:443, got %s", u.Host)
+				}
+				q := u.Query()
+				if q.Get("security") != "tls" {
+					t.Errorf("expected security=tls, got %s", q.Get("security"))
+				}
+				if q.Get("sni") != "trojan.example.com" {
+					t.Errorf("expected sni, got %s", q.Get("sni"))
+				}
+			},
+		},
+		{
+			name: "trojan with special password",
+			input: `proxies:
+  - name: "trojan-special"
+    type: trojan
+    server: trojan.example.com
+    port: 443
+    password: "p@ss/w0rd"
+    servername: trojan.example.com`,
+			checkURL: func(t *testing.T, rawURL string) {
+				u, err := parseTrojanTestURL(rawURL)
+				if err != nil {
+					t.Fatal(err)
+				}
+				// Password should be URL-encoded, so when parsed it comes back decoded
+				if u.User.Username() != "p@ss/w0rd" {
+					t.Errorf("expected decoded password p@ss/w0rd, got %s", u.User.Username())
+				}
+			},
+		},
+		{
+			name: "trojan with ws transport",
+			input: `proxies:
+  - name: "trojan-ws"
+    type: trojan
+    server: ws.example.com
+    port: 443
+    password: "secret"
+    network: ws
+    ws-opts:
+      path: /trojan
+      headers:
+        Host: cdn.example.com`,
+			checkURL: func(t *testing.T, rawURL string) {
+				u, err := parseTrojanTestURL(rawURL)
+				if err != nil {
+					t.Fatal(err)
+				}
+				q := u.Query()
+				if q.Get("type") != "ws" {
+					t.Errorf("expected type=ws, got %s", q.Get("type"))
+				}
+				if q.Get("path") != "/trojan" {
+					t.Errorf("expected path=/trojan, got %s", q.Get("path"))
+				}
+				if q.Get("host") != "cdn.example.com" {
+					t.Errorf("expected host=cdn.example.com, got %s", q.Get("host"))
+				}
+			},
+		},
+		{
+			name: "trojan with grpc",
+			input: `proxies:
+  - name: "trojan-grpc"
+    type: trojan
+    server: grpc.example.com
+    port: 443
+    password: "secret"
+    network: grpc
+    grpc-opts:
+      grpc-service-name: trojangrpc`,
+			checkURL: func(t *testing.T, rawURL string) {
+				u, err := parseTrojanTestURL(rawURL)
+				if err != nil {
+					t.Fatal(err)
+				}
+				q := u.Query()
+				if q.Get("type") != "grpc" {
+					t.Errorf("expected type=grpc, got %s", q.Get("type"))
+				}
+				if q.Get("serviceName") != "trojangrpc" {
+					t.Errorf("expected serviceName=trojangrpc, got %s", q.Get("serviceName"))
+				}
+			},
+		},
+		{
+			name: "trojan with servername fallback",
+			input: `proxies:
+  - name: "trojan-sn"
+    type: trojan
+    server: trojan.example.com
+    port: 443
+    password: "secret"
+    servername: fallback.example.com`,
+			checkURL: func(t *testing.T, rawURL string) {
+				u, err := parseTrojanTestURL(rawURL)
+				if err != nil {
+					t.Fatal(err)
+				}
+				q := u.Query()
+				if q.Get("sni") != "fallback.example.com" {
+					t.Errorf("expected sni=fallback.example.com, got %s", q.Get("sni"))
+				}
+			},
+		},
+		{
+			name: "trojan with h2 transport",
+			input: `proxies:
+  - name: "trojan-h2"
+    type: trojan
+    server: h2.example.com
+    port: 443
+    password: "secret"
+    network: h2
+    h2-opts:
+      path: /h2trojan
+      host:
+        - h2.example.com`,
+			checkURL: func(t *testing.T, rawURL string) {
+				u, err := parseTrojanTestURL(rawURL)
+				if err != nil {
+					t.Fatal(err)
+				}
+				q := u.Query()
+				if q.Get("type") != "h2" {
+					t.Errorf("expected type=h2, got %s", q.Get("type"))
+				}
+				if q.Get("path") != "/h2trojan" {
+					t.Errorf("expected path=/h2trojan, got %s", q.Get("path"))
+				}
+				if q.Get("host") != "h2.example.com" {
+					t.Errorf("expected host=h2.example.com, got %s", q.Get("host"))
+				}
+			},
+		},
+		{
+			name: "trojan with reality",
+			input: `proxies:
+  - name: "trojan-reality"
+    type: trojan
+    server: reality.example.com
+    port: 443
+    password: "secret"
+    client-fingerprint: chrome
+    reality-opts:
+      public-key: realpubkey
+      short-id: aabb`,
+			checkURL: func(t *testing.T, rawURL string) {
+				u, err := parseTrojanTestURL(rawURL)
+				if err != nil {
+					t.Fatal(err)
+				}
+				q := u.Query()
+				if q.Get("security") != "reality" {
+					t.Errorf("expected security=reality, got %s", q.Get("security"))
+				}
+				if q.Get("pbk") != "realpubkey" {
+					t.Errorf("expected pbk=realpubkey, got %s", q.Get("pbk"))
+				}
+				if q.Get("sid") != "aabb" {
+					t.Errorf("expected sid=aabb, got %s", q.Get("sid"))
+				}
+				if q.Get("fp") != "chrome" {
+					t.Errorf("expected fp=chrome, got %s", q.Get("fp"))
+				}
+			},
+		},
+		{
+			name: "trojan with space in password",
+			input: `proxies:
+  - name: "trojan-space"
+    type: trojan
+    server: example.com
+    port: 443
+    password: "foo bar"`,
+			checkURL: func(t *testing.T, rawURL string) {
+				u, err := parseTrojanTestURL(rawURL)
+				if err != nil {
+					t.Fatal(err)
+				}
+				// url.User encodes space as %20, not +
+				if u.User.Username() != "foo bar" {
+					t.Errorf("expected 'foo bar', got %s", u.User.Username())
+				}
+			},
+		},
+		{
+			name: "trojan missing password skipped",
+			input: `proxies:
+  - name: "trojan-no-pass"
+    type: trojan
+    server: example.com
+    port: 443`,
+			checkURL: nil,
+		},
+		{
+			name: "trojan IPv6 server",
+			input: `proxies:
+  - name: "trojan-ipv6"
+    type: trojan
+    server: "2001:db8::1"
+    port: 443
+    password: "secret"`,
+			checkURL: func(t *testing.T, rawURL string) {
+				u, err := parseTrojanTestURL(rawURL)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if u.Host != "[2001:db8::1]:443" {
+					t.Errorf("expected [2001:db8::1]:443, got %s", u.Host)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := string(FromClash([]byte(tt.input)))
+
+			if tt.checkURL == nil {
+				if result != "" {
+					t.Errorf("expected empty result, got %q", result)
+				}
+				return
+			}
+
+			line := strings.TrimSpace(result)
+			if !strings.HasPrefix(line, "trojan://") {
+				t.Fatalf("expected trojan:// prefix, got %q", line)
+			}
+			tt.checkURL(t, line)
+		})
+	}
+}
+
+func TestMixedProtocols(t *testing.T) {
+	input := `proxies:
+  - name: "http"
+    type: http
+    server: 1.2.3.4
+    port: 8080
+  - name: "vmess"
+    type: vmess
+    server: vmess.example.com
+    port: 443
+    uuid: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    alterId: 0
+    cipher: auto
+    tls: true
+  - name: "vless"
+    type: vless
+    server: vless.example.com
+    port: 443
+    uuid: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    tls: true
+  - name: "trojan"
+    type: trojan
+    server: trojan.example.com
+    port: 443
+    password: "secret"
+  - name: "ss"
+    type: ss
+    server: ss.example.com
+    port: 443
+    cipher: aes-256-gcm
+    password: "sspass"
+  - name: "socks5"
+    type: socks5
+    server: 5.6.7.8
+    port: 1080`
+
+	result := string(FromClash([]byte(input)))
+	lines := strings.Split(strings.TrimSpace(result), "\n")
+
+	if len(lines) != 6 {
+		t.Fatalf("expected 6 proxy URLs, got %d: %v", len(lines), lines)
+	}
+
+	if !strings.HasPrefix(lines[0], "http://") {
+		t.Errorf("line 0: expected http://, got %s", lines[0])
+	}
+	if !strings.HasPrefix(lines[1], "vmess://") {
+		t.Errorf("line 1: expected vmess://, got %s", lines[1])
+	}
+	if !strings.HasPrefix(lines[2], "vless://") {
+		t.Errorf("line 2: expected vless://, got %s", lines[2])
+	}
+	if !strings.HasPrefix(lines[3], "trojan://") {
+		t.Errorf("line 3: expected trojan://, got %s", lines[3])
+	}
+	if !strings.HasPrefix(lines[4], "ss://") {
+		t.Errorf("line 4: expected ss://, got %s", lines[4])
+	}
+	if !strings.HasPrefix(lines[5], "socks5://") {
+		t.Errorf("line 5: expected socks5://, got %s", lines[5])
+	}
+}
+
+// parseVlessTestURL parses a vless:// URL for test assertions.
+func parseVlessTestURL(rawURL string) (*url.URL, error) {
+	return url.Parse(rawURL)
+}
+
+// parseTrojanTestURL parses a trojan:// URL for test assertions.
+func parseTrojanTestURL(rawURL string) (*url.URL, error) {
+	return url.Parse(rawURL)
 }

--- a/internal/transformer_test.go
+++ b/internal/transformer_test.go
@@ -137,6 +137,35 @@ socks-port: 7891`,
 			expected: "",
 		},
 		{
+			name: "https proxy",
+			input: `proxies:
+  - name: "https-proxy"
+    type: https
+    server: 5.6.7.8
+    port: 8443`,
+			expected: "https://5.6.7.8:8443\n",
+		},
+		{
+			name: "socks4 proxy",
+			input: `proxies:
+  - name: "socks4-proxy"
+    type: socks4
+    server: 9.9.9.9
+    port: 1080`,
+			expected: "socks4://9.9.9.9:1080\n",
+		},
+		{
+			name: "http proxy with auth credentials",
+			input: `proxies:
+  - name: "auth-proxy"
+    type: http
+    server: 1.2.3.4
+    port: 8080
+    username: "user1"
+    password: "pass1"`,
+			expected: "http://user1:pass1@1.2.3.4:8080\n",
+		},
+		{
 			name: "vmess proxy skipped",
 			input: `proxies:
   - name: "vmess-proxy"
@@ -144,6 +173,32 @@ socks-port: 7891`,
     server: 1.2.3.4
     port: 443`,
 			expected: "",
+		},
+		{
+			name: "float64 port",
+			input: `proxies:
+  - name: "float-port"
+    type: http
+    server: 1.2.3.4
+    port: 8080.0`,
+			expected: "http://1.2.3.4:8080\n",
+		},
+		{
+			name: "bool port skipped gracefully",
+			input: `proxies:
+  - name: "valid"
+    type: http
+    server: 1.2.3.4
+    port: 8080
+  - name: "bool-port"
+    type: http
+    server: 5.6.7.8
+    port: true
+  - name: "valid2"
+    type: socks5
+    server: 9.10.11.12
+    port: 1080`,
+			expected: "http://1.2.3.4:8080\nsocks5://9.10.11.12:1080\n",
 		},
 		{
 			name: "mixed valid and invalid proxies",

--- a/internal/transformer_test.go
+++ b/internal/transformer_test.go
@@ -43,7 +43,7 @@ func TestFromClash(t *testing.T) {
     port: 443
     cipher: chacha20-ietf-poly1305
     password: "test123"`,
-			expected: "ss://" + base64.URLEncoding.EncodeToString([]byte("chacha20-ietf-poly1305:test123")) + "@9.10.11.12:443\n",
+			expected: "ss://" + base64.StdEncoding.EncodeToString([]byte("chacha20-ietf-poly1305:test123")) + "@9.10.11.12:443\n",
 		},
 		{
 			name: "clash config with no proxies",

--- a/internal/transformer_test.go
+++ b/internal/transformer_test.go
@@ -279,12 +279,16 @@ socks-port: 7891`,
 			expected: "http://[::1]:8080\n",
 		},
 		{
-			name: "exact 10MB YAML accepted",
+			// 10MB is the maxYAMLSize boundary: input passes the size gate and
+			// reaches the YAML parser, which fails on non-YAML content, so output is empty.
+			name: "input at 10MB size limit reaches parser and yields empty output on parse failure",
 			input: strings.Repeat("x", 10*1024*1024),
 			expected: "",
 		},
 		{
-			name: "oversized YAML rejected",
+			// 11MB exceeds maxYAMLSize: input is rejected by the size gate
+			// before YAML parsing, so output is empty without a parse attempt.
+			name: "input above 10MB size limit rejected by size gate before parsing",
 			input: strings.Repeat("x", 11*1024*1024), // 11MB
 			expected: "",
 		},

--- a/internal/transformer_test.go
+++ b/internal/transformer_test.go
@@ -990,3 +990,41 @@ func parseVlessTestURL(rawURL string) (*url.URL, error) {
 func parseTrojanTestURL(rawURL string) (*url.URL, error) {
 	return url.Parse(rawURL)
 }
+
+// TestFlexPortFloatRejection locks the contract that float ports must be
+// integral, finite, and within the valid TCP/UDP range. Catches CodeRabbit's
+// concern that int(f) silently truncates non-integer floats and accepts
+// out-of-range or non-finite values.
+func TestFlexPortFloatRejection(t *testing.T) {
+	tests := []struct {
+		name      string
+		yamlPort  string // raw YAML scalar for the port field
+		wantEmpty bool   // FromClash returns empty when port is invalid
+	}{
+		{name: "integer port accepted", yamlPort: "8080", wantEmpty: false},
+		{name: "float equal to integer accepted", yamlPort: "8080.0", wantEmpty: false},
+		{name: "non-integer float rejected", yamlPort: "8080.5", wantEmpty: true},
+		{name: "fractional float rejected", yamlPort: "8080.7", wantEmpty: true},
+		{name: "negative float rejected", yamlPort: "-1.0", wantEmpty: true},
+		{name: "out-of-range float rejected", yamlPort: "99999.0", wantEmpty: true},
+		{name: "NaN rejected", yamlPort: ".nan", wantEmpty: true},
+		{name: "positive infinity rejected", yamlPort: ".inf", wantEmpty: true},
+		{name: "negative infinity rejected", yamlPort: "-.inf", wantEmpty: true},
+		{name: "zero rejected", yamlPort: "0", wantEmpty: true},
+		{name: "negative integer rejected", yamlPort: "-1", wantEmpty: true},
+		{name: "above 65535 rejected", yamlPort: "65536", wantEmpty: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			yaml := "proxies:\n  - name: test\n    type: http\n    server: example.com\n    port: " + tt.yamlPort + "\n"
+			result := string(FromClash([]byte(yaml)))
+			if tt.wantEmpty && result != "" {
+				t.Errorf("port %q: expected empty result, got %q", tt.yamlPort, result)
+			}
+			if !tt.wantEmpty && result == "" {
+				t.Errorf("port %q: expected non-empty result, got empty", tt.yamlPort)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implements a Clash YAML configuration parser to extract proxy URLs from remote Clash configs, addressing the need to parse configs from sources like github.com/go4sharing/sub and github.com/ripaojiedian/freenode.

## What Changed

Added `FromClash` transformer that:
- Parses Clash YAML configs and extracts proxy entries
- Supports http, https, socks4, socks5, and shadowsocks proxy types
- Validates port ranges (1-65535) and handles multiple port formats (int, float64, string)
- Includes 10MB size limit to prevent OOM attacks
- Skips complex protocols (vmess, vless, trojan) that require complete parameter sets

Comprehensive test coverage (18 test cases) including edge cases:
- Invalid YAML
- Missing required fields
- Port validation
- Oversized inputs
- Mixed valid/invalid entries

Fixes #14

## Summary by Sourcery

Add a Clash YAML configuration transformer that extracts proxy URLs into a normalized text format and wires it into the existing transformer registry.

New Features:
- Introduce a FromClash transformer to parse Clash YAML configs and emit http, https, socks4, socks5, and Shadowsocks proxy URLs.

Build:
- Promote gopkg.in/yaml.v3 to a direct dependency for YAML parsing.

Tests:
- Add unit tests for the Clash transformer covering valid configs, missing fields, invalid YAML, port validation, protocol filtering, and oversized input handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Clash proxy transformer that extracts proxy URLs for HTTP, HTTPS, SOCKS4/5, Shadowsocks, Vmess, Vless and Trojan, with transport (WS/GRPC/H2) and TLS/Reality options.

* **Bug Fixes / Validation**
  * Enforced port parsing and 1–65535 range, server-field validation, and a 10MB YAML input size limit; malformed or unsupported entries are skipped.

* **Tests**
  * Added comprehensive tests covering protocols, encoding, edge cases, validation, mixed entries, and oversized payloads.

* **Dependencies**
  * Promoted YAML library to a direct dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gfpcom/free-proxy-list/pull/49)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->