### PR TITLE
Add GitHub Actions workflow for test and lint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
         go-version: '1.25'
     - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,8 @@ jobs:
       with:
         go-version: '1.25'
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v9
       with:
-        version: 'v2.12.2'
+        version: v2.12
     - name: Lint
       run: make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test and Lint
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.25'
+    - name: Test
+      run: make test
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.25'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: latest
+    - name: Lint
+      run: make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,10 @@ jobs:
         go-version: '1.26'
     - name: Test
       run: make test
-      
     - name: Upload coverage reports to Codecov
-    uses: codecov/codecov-action@v5
-    with:
-      token: ${{ secrets.CODECOV_TOKEN }}
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,6 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: latest
+        version: v2.12
     - name: Lint
       run: make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,6 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v2.12
+        version: 'v2.12.2'
     - name: Lint
       run: make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,22 +8,22 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
     - name: Test
       run: make test
 
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v9
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test and Lint
 
 on:
-  push:
+  pull_request:
     branches: [ main ]
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,11 @@ jobs:
         go-version: '1.26'
     - name: Test
       run: make test
+      
+    - name: Upload coverage reports to Codecov
+    uses: codecov/codecov-action@v5
+    with:
+      token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ go.work.sum
 
 # env file
 .env
+
+coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build:
 	go build -v -o gfp cmd/main.go
 
 test:
-	go test ./...
+	go test -coverprofile=coverage.txt ./...
 
 lint:
 	golangci-lint run

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
-.PHONY: update build clone-wiki update-wiki
+.PHONY: update build clone-wiki update-wiki test lint
 
 update:
 	go build -o gfp cmd/main.go && ./gfp
 
 build:
 	go build -v -o gfp cmd/main.go
+
+test:
+	go test ./...
+
+lint:
+	golangci-lint run
 
 # clone-wiki: clone the wiki repo and copy generated list files into wiki/lists
 clone-wiki:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
   <img src="https://raw.githubusercontent.com/wiki/gfpcom/free-proxy-list/lists/total.svg">
   <img src="https://img.shields.io/github/last-commit/gfpcom/free-proxy-list.svg">
   <img src="https://img.shields.io/github/license/gfpcom/free-proxy-list.svg">
+  <img src="https://codecov.io/gh/gfpcom/free-proxy-list/branch/main/graph/badge.svg">
   
   <br>
   <br>

--- a/internal/db.go
+++ b/internal/db.go
@@ -27,8 +27,8 @@ func WriteTo(dir string) {
 	files := make(map[string]*os.File)
 	defer func() {
 		for _, f := range files {
-			f.Sync() // nolint: errcheck
-			f.Close()
+			_ = f.Sync()  // nolint: errcheck
+			_ = f.Close() // nolint: errcheck
 		}
 	}()
 
@@ -81,7 +81,7 @@ func WriteTotalAndUpdateReadme(dir string, counters map[string]int) {
 	svgURL := fmt.Sprintf("https://img.shields.io/badge/total-%d-blue", total)
 	resp, err := httpGet(svgURL)
 	if err == nil && resp != nil {
-		defer resp.Close()
+		defer func() { _ = resp.Close() }() // nolint: errcheck
 		// write to list/total.svg
 		outPath := filepath.Join(dir, "total.svg")
 		_ = os.WriteFile(outPath, resp.Bytes(), 0644) // nolint: errcheck
@@ -92,10 +92,10 @@ func WriteTotalAndUpdateReadme(dir string, counters map[string]int) {
 	for _, proto := range protocols {
 		count := counters[proto]
 		url := fmt.Sprintf("https://raw.githubusercontent.com/wiki/gfpcom/free-proxy-list/lists/%s.txt", proto)
-		tableContent.WriteString(fmt.Sprintf("| %s | %d | %s |\n",
+		fmt.Fprintf(&tableContent, "| %s | %d | %s |\n",
 			strings.ToUpper(proto),
 			count,
-			url))
+			url)
 	}
 
 	// Update README.md
@@ -143,7 +143,7 @@ func httpGet(url string) (*respWrap, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // nolint: errcheck
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("status %d", resp.StatusCode)
 	}

--- a/internal/db.go
+++ b/internal/db.go
@@ -26,8 +26,6 @@ func Save(it *Proxy) {
 func WriteTo(dir string) {
 	files := make(map[string]*os.File)
 	defer func() {
-		for _, f := range files {
-	defer func() {
 		for proto, f := range files {
 			if err := f.Sync(); err != nil {
 				fmt.Fprintf(os.Stderr, "sync failed for %s: %v\n", proto, err)
@@ -35,8 +33,6 @@ func WriteTo(dir string) {
 			if err := f.Close(); err != nil {
 				fmt.Fprintf(os.Stderr, "close failed for %s: %v\n", proto, err)
 			}
-		}
-	}()
 		}
 	}()
 

--- a/internal/db.go
+++ b/internal/db.go
@@ -27,8 +27,16 @@ func WriteTo(dir string) {
 	files := make(map[string]*os.File)
 	defer func() {
 		for _, f := range files {
-			_ = f.Sync()  // nolint: errcheck
-			_ = f.Close() // nolint: errcheck
+	defer func() {
+		for proto, f := range files {
+			if err := f.Sync(); err != nil {
+				fmt.Fprintf(os.Stderr, "sync failed for %s: %v\n", proto, err)
+			}
+			if err := f.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "close failed for %s: %v\n", proto, err)
+			}
+		}
+	}()
 		}
 	}()
 

--- a/internal/db.go
+++ b/internal/db.go
@@ -143,7 +143,7 @@ func httpGet(url string) (*respWrap, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Close() // nolint: errcheck
+	defer resp.Body.Close() // nolint: errcheck
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("status %d", resp.StatusCode)
 	}

--- a/internal/db.go
+++ b/internal/db.go
@@ -81,7 +81,7 @@ func WriteTotalAndUpdateReadme(dir string, counters map[string]int) {
 	svgURL := fmt.Sprintf("https://img.shields.io/badge/total-%d-blue", total)
 	resp, err := httpGet(svgURL)
 	if err == nil && resp != nil {
-		defer func() { _ = resp.Close() }() // nolint: errcheck
+		defer resp.Close() // nolint: errcheck
 		// write to list/total.svg
 		outPath := filepath.Join(dir, "total.svg")
 		_ = os.WriteFile(outPath, resp.Bytes(), 0644) // nolint: errcheck
@@ -143,7 +143,7 @@ func httpGet(url string) (*respWrap, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = resp.Body.Close() }() // nolint: errcheck
+	defer resp.Close() // nolint: errcheck
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("status %d", resp.StatusCode)
 	}

--- a/internal/fetch.go
+++ b/internal/fetch.go
@@ -31,7 +31,7 @@ func Fetch(proto, src string, transformer Transformer, parser Parser) int {
 	if err != nil {
 		return 0
 	}
-	defer resp.Close() // nolint: errcheck
+	defer resp.Body.Close() // nolint: errcheck
 
 	buf, _ := io.ReadAll(resp.Body)
 

--- a/internal/fetch.go
+++ b/internal/fetch.go
@@ -31,7 +31,7 @@ func Fetch(proto, src string, transformer Transformer, parser Parser) int {
 	if err != nil {
 		return 0
 	}
-	defer func() { _ = resp.Body.Close() }() // nolint: errcheck
+	defer resp.Close() // nolint: errcheck
 
 	buf, _ := io.ReadAll(resp.Body)
 

--- a/internal/fetch.go
+++ b/internal/fetch.go
@@ -31,7 +31,7 @@ func Fetch(proto, src string, transformer Transformer, parser Parser) int {
 	if err != nil {
 		return 0
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // nolint: errcheck
 
 	buf, _ := io.ReadAll(resp.Body)
 


### PR DESCRIPTION
## Description
This PR adds automated testing and linting to the project using GitHub Actions.

## Changes
- Create `.github/workflows/test.yml` to run tests and lint checks on push to main
- Add `make test` and `make lint` targets to Makefile for consistency between local development and CI
- Use Make targets in the workflow for easier maintenance

## Benefits
- Automated test and lint checks on every push to main
- Consistent command interface between local development and CI pipeline
- Tests will catch regressions early in the development process

## Summary by Sourcery

Introduce CI automation for testing and linting, and adjust Go code and Makefile to support the new workflow and linting requirements.

Enhancements:
- Improve file and HTTP response handling in database and fetch utilities to satisfy linting and error-handling standards.

Build:
- Add make test and make lint targets for consistent local and CI commands.

CI:
- Add a GitHub Actions workflow to run tests and Go linting on pull requests to main.

Tests:
- Run go test across all packages in CI via the new workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI workflow to run tests and linters on pull requests to the main branch.
  * Added local build targets for running tests and linting.
  * Made internal cleanup and resource-close changes to improve lint compliance and consistency in error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gfpcom/free-proxy-list/pull/50)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->