### PR TITLE
feat: add link transformer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ You can use dynamic tokens in the source URLs to fetch lists that are generated 
 **Format:** `url,transformer,parser`
 
 -   **`url`**: (Required) The URL of the proxy list.
--   **`transformer`**: (Optional) Specifies how to transform the raw data before parsing. The default is `raw` (no transformation). We also have `base64` for sources encoded in Base64.
+-   **`transformer`**: (Optional) Specifies how to transform the raw data before parsing. The default is `raw` (no transformation). We also have `base64` for sources encoded in Base64 and `regex:<pattern>` for extracting linked proxy-list URLs from documents such as README files, downloading those lists, and merging their content before parsing.
 -   **`parser`**: (Optional) Specifies how to parse individual lines from the source. The default `ParseProxyURL` handles standard proxy URLs. Other options include `ColonURL` (for `ip:port` formats) and `SpaceURL` (for `ip port` formats).
 
 **Example:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ You can use dynamic tokens in the source URLs to fetch lists that are generated 
 **Format:** `url,transformer,parser`
 
 -   **`url`**: (Required) The URL of the proxy list.
--   **`transformer`**: (Optional) Specifies how to transform the raw data before parsing. The default is `raw` (no transformation). We also have `base64` for sources encoded in Base64 and `regex:<pattern>` for extracting linked proxy-list URLs from documents such as README files, downloading those lists, and merging their content before parsing.
+-   **`transformer`**: (Optional) Specifies how to transform the raw data before parsing. The default is `raw` (no transformation). We also have `base64` for sources encoded in Base64, `clash` for Clash YAML, and `link[:transformer-keyword]` for extracting link-like strings from documents such as README files. For example, `link:base64-fn0618` fetches links containing `fn0618`, decodes each linked response as Base64, and merges the transformed proxy links before parsing.
 -   **`parser`**: (Optional) Specifies how to parse individual lines from the source. The default `ParseProxyURL` handles standard proxy URLs. Other options include `ColonURL` (for `ip:port` formats) and `SpaceURL` (for `ip port` formats).
 
 **Example:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ You can use dynamic tokens in the source URLs to fetch lists that are generated 
 **Format:** `url,transformer,parser`
 
 -   **`url`**: (Required) The URL of the proxy list.
--   **`transformer`**: (Optional) Specifies how to transform the raw data before parsing. The default is `raw` (no transformation). We also have `base64` for sources encoded in Base64, `clash` for Clash YAML, and `link[:transformer-keyword]` for extracting link-like strings from documents such as README files. For example, `link:base64-fn0618` fetches links containing `fn0618`, decodes each linked response as Base64, and merges the transformed proxy links before parsing.
+-   **`transformer`**: (Optional) Specifies how to transform the raw data before parsing. The default is `raw` (no transformation). Transformer options use `name[:options]`. We also have `base64` for sources encoded in Base64, `clash` for Clash YAML, and `link[:transformer-keyword]` for extracting link-like strings from documents such as README files. For example, `link:base64-fn0618` fetches links containing `fn0618`, decodes each linked response as Base64, and merges the transformed proxy links before parsing.
 -   **`parser`**: (Optional) Specifies how to parse individual lines from the source. The default `ParseProxyURL` handles standard proxy URLs. Other options include `ColonURL` (for `ip:port` formats) and `SpaceURL` (for `ip port` formats).
 
 **Example:**
@@ -80,7 +80,7 @@ http://myproxies.com/list,base64,ColonURL
 If a proxy source uses a unique encoding or format (e.g., Gzip, custom text format), you might need to add a new `Transformer`.
 
 1.  **Go to `internal/transformer.go`**.
-2.  Define a new function that matches the `Transformer` type: `func([]byte) []byte`. This function will take the raw response body and return the transformed body.
+2.  Define a new function that matches the `Transformer` type: `func([]byte, string) []byte`. This function will take the raw response body plus optional `name[:options]` data and return the transformed body.
 3.  **Register your new transformer** in the `init()` function within `internal/transformer.go`, giving it a name.
 
 ```go
@@ -91,7 +91,7 @@ func init() {
 }
 
 // Define your transformer function
-func MyNewTransformer(buf []byte) []byte {
+func MyNewTransformer(buf []byte, options string) []byte {
     // ... your transformation logic ...
     return transformedBuf
 }

--- a/internal/fetch.go
+++ b/internal/fetch.go
@@ -35,7 +35,7 @@ func Fetch(proto, src string, transformer Transformer, parser Parser) int {
 
 	buf, _ := io.ReadAll(resp.Body)
 
-	s := bufio.NewScanner(bytes.NewReader(transformer(buf)))
+	s := bufio.NewScanner(bytes.NewReader(transformer(buf, "")))
 
 	var line string
 

--- a/internal/fetch.go
+++ b/internal/fetch.go
@@ -25,7 +25,7 @@ var (
 	}
 )
 
-func Fetch(proto, src string, transformer Transformer, parser Parser) int {
+func Fetch(proto, src string, transformer Transformer, transformerOptions string, parser Parser) int {
 	var total int
 	resp, err := client.Get(src)
 	if err != nil {
@@ -35,7 +35,7 @@ func Fetch(proto, src string, transformer Transformer, parser Parser) int {
 
 	buf, _ := io.ReadAll(resp.Body)
 
-	s := bufio.NewScanner(bytes.NewReader(transformer(buf, "")))
+	s := bufio.NewScanner(bytes.NewReader(transformer(buf, transformerOptions)))
 
 	var line string
 

--- a/internal/fetch_test.go
+++ b/internal/fetch_test.go
@@ -10,10 +10,10 @@ func TestFetch(t *testing.T) {
 		t.Skip("Skipping test in GitHub Actions environment")
 	}
 
-	// Fetch("", "https://github.com/mfuu/v2ray/raw/refs/heads/master/merge/merge.txt", FromRaw, ParseProxyURL)
-	// Fetch("", "https://github.com/snakem982/proxypool/raw/refs/heads/main/source/v2ray-2.txt", FromBase64, ParseProxyURL)
+	// Fetch("", "https://github.com/mfuu/v2ray/raw/refs/heads/master/merge/merge.txt", FromRaw, "", ParseProxyURL)
+	// Fetch("", "https://github.com/snakem982/proxypool/raw/refs/heads/main/source/v2ray-2.txt", FromBase64, "", ParseProxyURL)
 
-	src, transformer, parser := parseLine("https://github.com/zloi-user/hideip.me/raw/refs/heads/master/http.txt,,ColonURL")
-	Fetch("http", src, transformer, parser)
+	src, transformer, transformerOptions, parser := parseLine("https://github.com/zloi-user/hideip.me/raw/refs/heads/master/http.txt,,ColonURL")
+	Fetch("http", src, transformer, transformerOptions, parser)
 
 }

--- a/internal/load.go
+++ b/internal/load.go
@@ -17,6 +17,7 @@ func Load(proto string, content []byte) error {
 
 	var line, src string
 	var transformer Transformer
+	var transformerOptions string
 	var parser Parser
 	for s.Scan() {
 		line = strings.TrimSpace(s.Text())
@@ -25,13 +26,13 @@ func Load(proto string, content []byte) error {
 		}
 
 		if strings.HasPrefix(line, "https://") || strings.HasPrefix(line, "http://") {
-			src, transformer, parser = parseLine(line)
+			src, transformer, transformerOptions, parser = parseLine(line)
 
 			if src == "" {
 				continue
 			}
 
-			log.Printf("> %v %s", Fetch(proto, src, transformer, parser), src)
+			log.Printf("> %v %s", Fetch(proto, src, transformer, transformerOptions, parser), src)
 		}
 
 	}
@@ -104,13 +105,14 @@ func applyTokenizer(url string) string {
 	return url
 }
 
-func parseLine(line string) (string, Transformer, Parser) {
+func parseLine(line string) (string, Transformer, string, Parser) {
 
 	if strings.HasPrefix(line, "https://") || strings.HasPrefix(line, "http://") {
 		items := strings.Split(line, ",")
 
 		var src string
-		transformer := func(buf []byte, _ string) []byte { return FromRaw(buf) }
+		transformer := FromRaw
+		transformerOptions := ""
 		parser := ParseProxyURL
 
 		if len(items) > 0 {
@@ -118,15 +120,15 @@ func parseLine(line string) (string, Transformer, Parser) {
 		}
 
 		if len(items) > 1 {
-			transformer = GetTransformer(strings.TrimSpace(items[1]))
+			transformer, transformerOptions = GetTransformer(strings.TrimSpace(items[1]))
 		}
 
 		if len(items) > 2 {
 			parser = GetParser(strings.TrimSpace(items[2]))
 		}
 
-		return src, transformer, parser
+		return src, transformer, transformerOptions, parser
 	}
 
-	return "", nil, nil
+	return "", nil, "", nil
 }

--- a/internal/load.go
+++ b/internal/load.go
@@ -3,12 +3,12 @@ package internal
 import (
 	"bufio"
 	"bytes"
-	"log"
-	"strings"
 	"fmt"
-	"time"
+	"log"
 	"regexp"
 	"strconv"
+	"strings"
+	"time"
 )
 
 func Load(proto string, content []byte) error {
@@ -43,16 +43,16 @@ func roundToNearestIncrement(currentHour int, increment int) int {
 	if increment <= 0 || increment > 24 {
 		return currentHour
 	}
-	
+
 	// Generate valid hours based on increment
 	var validHours []int
 	for h := 0; h < 24; h += increment {
 		validHours = append(validHours, h)
 	}
-	
+
 	closest := 0
 	minDiff := 24
-	
+
 	for _, validHour := range validHours {
 		diff := currentHour - validHour
 		if diff < 0 {
@@ -61,13 +61,13 @@ func roundToNearestIncrement(currentHour int, increment int) int {
 		if diff > 12 {
 			diff = 24 - diff
 		}
-		
+
 		if diff < minDiff {
 			minDiff = diff
 			closest = validHour
 		}
 	}
-	
+
 	return closest
 }
 
@@ -110,7 +110,7 @@ func parseLine(line string) (string, Transformer, Parser) {
 		items := strings.Split(line, ",")
 
 		var src string
-		transformer := FromRaw
+		transformer := func(buf []byte, _ string) []byte { return FromRaw(buf) }
 		parser := ParseProxyURL
 
 		if len(items) > 0 {

--- a/internal/transformer.go
+++ b/internal/transformer.go
@@ -5,9 +5,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
 	"net"
+	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -30,6 +33,10 @@ func RegisterTransformer(name string, t Transformer) {
 }
 
 func GetTransformer(name string) Transformer {
+	if strings.HasPrefix(name, "regex:") {
+		return FromRegexLinks(strings.TrimPrefix(name, "regex:"))
+	}
+
 	if t, ok := Transformers[name]; ok {
 		return t
 	}
@@ -48,6 +55,51 @@ func FromBase64(buf []byte) []byte {
 	}
 
 	return decoded
+}
+
+// FromRegexLinks extracts URLs from a document with pattern and returns the
+// concatenated contents downloaded from those URLs.
+func FromRegexLinks(pattern string) Transformer {
+	return func(buf []byte) []byte {
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return []byte{}
+		}
+
+		matches := re.FindAllSubmatch(buf, -1)
+		if len(matches) == 0 {
+			return []byte{}
+		}
+
+		var result bytes.Buffer
+		seen := map[string]struct{}{}
+		for _, match := range matches {
+			link := match[0]
+			if len(match) > 1 {
+				link = match[1]
+			}
+			rawURL := strings.TrimSpace(string(link))
+			if _, ok := seen[rawURL]; ok || rawURL == "" {
+				continue
+			}
+			seen[rawURL] = struct{}{}
+
+			resp, err := client.Get(rawURL)
+			if err != nil {
+				continue
+			}
+			body, err := io.ReadAll(resp.Body)
+			resp.Body.Close() // nolint: errcheck
+			if err != nil || resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+				continue
+			}
+
+			result.Write(bytes.TrimSpace(body))
+			result.WriteByte('\n')
+		}
+
+		return result.Bytes()
+	}
 }
 
 // FlexPort handles YAML port values that may be int, float, or string.

--- a/internal/transformer.go
+++ b/internal/transformer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -25,6 +26,16 @@ const (
 var (
 	Transformers               = map[string]Transformer{}
 	allowPrivateRegexLinkHosts = false
+	errUnsafeRegexLinkRedirect = errors.New("unsafe regex link redirect")
+	regexLinkClient            = &http.Client{
+		Transport: client.Transport,
+		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+			if !isAllowedRegexLink(req.URL.String()) {
+				return errUnsafeRegexLinkRedirect
+			}
+			return nil
+		},
+	}
 )
 
 func init() {
@@ -96,7 +107,7 @@ func FromLinks(buf []byte, spec string) []byte {
 		}
 		seen[rawURL] = struct{}{}
 
-		resp, err := client.Get(rawURL)
+		resp, err := regexLinkClient.Get(rawURL)
 		if err != nil {
 			continue
 		}

--- a/internal/transformer.go
+++ b/internal/transformer.go
@@ -62,7 +62,9 @@ func FromBase64(buf []byte) []byte {
 func FromRegexLinks(pattern string) Transformer {
 	re, err := regexp.Compile(pattern)
 	if err != nil {
-		return FromRaw
+		return func([]byte) []byte {
+			return []byte{}
+		}
 	}
 
 	return func(buf []byte) []byte {

--- a/internal/transformer.go
+++ b/internal/transformer.go
@@ -28,26 +28,31 @@ var (
 )
 
 func init() {
-	Transformers["base64"] = FromBase64
-	Transformers["clash"] = FromClash
+	Transformers["base64"] = func(buf []byte, _ string) []byte { return FromBase64(buf) }
+	Transformers["clash"] = func(buf []byte, _ string) []byte { return FromClash(buf) }
+	Transformers["link"] = FromLinks
 }
 
-type Transformer func([]byte) []byte
+type Transformer func(data []byte, options string) []byte
 
 func RegisterTransformer(name string, t Transformer) {
 	Transformers[name] = t
 }
 
-func GetTransformer(name string) Transformer {
-	if name == "link" || strings.HasPrefix(name, "link:") {
-		return FromLinks(strings.TrimPrefix(name, "link"))
-	}
-
+func GetTransformer(spec string) Transformer {
+	name, options := parseTransformerSpec(spec)
 	if t, ok := Transformers[name]; ok {
-		return t
+		return func(buf []byte, _ string) []byte {
+			return t(buf, options)
+		}
 	}
 
-	return FromRaw
+	return func(buf []byte, _ string) []byte { return FromRaw(buf) }
+}
+
+func parseTransformerSpec(spec string) (string, string) {
+	name, options, _ := strings.Cut(spec, ":")
+	return strings.TrimSpace(name), strings.TrimSpace(options)
 }
 
 func FromRaw(buf []byte) []byte {
@@ -68,53 +73,53 @@ var linkURLPattern = regexp.MustCompile(`https?://[^\s"'<>]+`)
 // FromLinks extracts link-like URLs from a document, optionally filters them by
 // keyword, downloads each unique URL, and applies the selected transformer to
 // the downloaded content before merging it into the result.
-func FromLinks(spec string) Transformer {
+func FromLinks(buf []byte, spec string) []byte {
 	transformer, keyword := parseLinkSpec(spec)
 
-	return func(buf []byte) []byte {
-		matches := linkURLPattern.FindAll(buf, maxRegexLinkCount)
-		if len(matches) == 0 {
-			return []byte{}
-		}
-
-		var result bytes.Buffer
-		seen := map[string]struct{}{}
-		for _, match := range matches {
-			rawURL := strings.Trim(string(match), " 	\r\n\"'<>)]}")
-			if keyword != "" && !strings.Contains(rawURL, keyword) {
-				continue
-			}
-			if _, ok := seen[rawURL]; ok || !isAllowedRegexLink(rawURL) {
-				continue
-			}
-			seen[rawURL] = struct{}{}
-
-			resp, err := client.Get(rawURL)
-			if err != nil {
-				continue
-			}
-			if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-				resp.Body.Close() // nolint: errcheck
-				continue
-			}
-			body, err := io.ReadAll(io.LimitReader(resp.Body, maxRegexLinkResponseBytes+1))
-			resp.Body.Close() // nolint: errcheck
-			if err != nil || len(body) > maxRegexLinkResponseBytes {
-				continue
-			}
-
-			result.Write(bytes.TrimSpace(transformer(body)))
-			result.WriteByte('\n')
-		}
-
-		return result.Bytes()
+	matches := linkURLPattern.FindAll(buf, -1)
+	if len(matches) == 0 {
+		return []byte{}
 	}
+
+	var result bytes.Buffer
+	seen := map[string]struct{}{}
+	for _, match := range matches {
+		rawURL := strings.Trim(string(match), " 	\r\n\"'<>)]}")
+		if keyword != "" && !strings.Contains(rawURL, keyword) {
+			continue
+		}
+		if _, ok := seen[rawURL]; ok || !isAllowedRegexLink(rawURL) {
+			continue
+		}
+		if len(seen) >= maxRegexLinkCount {
+			break
+		}
+		seen[rawURL] = struct{}{}
+
+		resp, err := client.Get(rawURL)
+		if err != nil {
+			continue
+		}
+		if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+			resp.Body.Close() // nolint: errcheck
+			continue
+		}
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxRegexLinkResponseBytes+1))
+		resp.Body.Close() // nolint: errcheck
+		if err != nil || len(body) > maxRegexLinkResponseBytes {
+			continue
+		}
+
+		result.Write(bytes.TrimSpace(transformer(body, "")))
+		result.WriteByte('\n')
+	}
+
+	return result.Bytes()
 }
 
 func parseLinkSpec(spec string) (Transformer, string) {
-	spec = strings.TrimPrefix(spec, ":")
 	if spec == "" {
-		return FromRaw, ""
+		return func(buf []byte, _ string) []byte { return FromRaw(buf) }, ""
 	}
 	if t, ok := Transformers[spec]; ok {
 		return t, ""
@@ -125,7 +130,7 @@ func parseLinkSpec(spec string) (Transformer, string) {
 			return t, strings.TrimPrefix(spec, prefix)
 		}
 	}
-	return FromRaw, spec
+	return func(buf []byte, _ string) []byte { return FromRaw(buf) }, spec
 }
 
 func isAllowedRegexLink(rawURL string) bool {

--- a/internal/transformer.go
+++ b/internal/transformer.go
@@ -39,8 +39,8 @@ func RegisterTransformer(name string, t Transformer) {
 }
 
 func GetTransformer(name string) Transformer {
-	if strings.HasPrefix(name, "regex:") {
-		return FromRegexLinks(strings.TrimPrefix(name, "regex:"))
+	if name == "link" || strings.HasPrefix(name, "link:") {
+		return FromLinks(strings.TrimPrefix(name, "link"))
 	}
 
 	if t, ok := Transformers[name]; ok {
@@ -63,18 +63,16 @@ func FromBase64(buf []byte) []byte {
 	return decoded
 }
 
-// FromRegexLinks extracts URLs from a document with pattern and returns the
-// concatenated contents downloaded from those URLs.
-func FromRegexLinks(pattern string) Transformer {
-	re, err := regexp.Compile(pattern)
-	if err != nil {
-		return func([]byte) []byte {
-			return []byte{}
-		}
-	}
+var linkURLPattern = regexp.MustCompile(`https?://[^\s"'<>]+`)
+
+// FromLinks extracts link-like URLs from a document, optionally filters them by
+// keyword, downloads each unique URL, and applies the selected transformer to
+// the downloaded content before merging it into the result.
+func FromLinks(spec string) Transformer {
+	transformer, keyword := parseLinkSpec(spec)
 
 	return func(buf []byte) []byte {
-		matches := re.FindAllSubmatch(buf, maxRegexLinkCount)
+		matches := linkURLPattern.FindAll(buf, maxRegexLinkCount)
 		if len(matches) == 0 {
 			return []byte{}
 		}
@@ -82,11 +80,10 @@ func FromRegexLinks(pattern string) Transformer {
 		var result bytes.Buffer
 		seen := map[string]struct{}{}
 		for _, match := range matches {
-			link := match[0]
-			if len(match) > 1 {
-				link = match[1]
+			rawURL := strings.Trim(string(match), " 	\r\n\"'<>)]}")
+			if keyword != "" && !strings.Contains(rawURL, keyword) {
+				continue
 			}
-			rawURL := strings.TrimSpace(string(link))
 			if _, ok := seen[rawURL]; ok || !isAllowedRegexLink(rawURL) {
 				continue
 			}
@@ -106,12 +103,29 @@ func FromRegexLinks(pattern string) Transformer {
 				continue
 			}
 
-			result.Write(bytes.TrimSpace(body))
+			result.Write(bytes.TrimSpace(transformer(body)))
 			result.WriteByte('\n')
 		}
 
 		return result.Bytes()
 	}
+}
+
+func parseLinkSpec(spec string) (Transformer, string) {
+	spec = strings.TrimPrefix(spec, ":")
+	if spec == "" {
+		return FromRaw, ""
+	}
+	if t, ok := Transformers[spec]; ok {
+		return t, ""
+	}
+	for name, t := range Transformers {
+		prefix := name + "-"
+		if strings.HasPrefix(spec, prefix) {
+			return t, strings.TrimPrefix(spec, prefix)
+		}
+	}
+	return FromRaw, spec
 }
 
 func isAllowedRegexLink(rawURL string) bool {

--- a/internal/transformer.go
+++ b/internal/transformer.go
@@ -60,12 +60,12 @@ func FromBase64(buf []byte) []byte {
 // FromRegexLinks extracts URLs from a document with pattern and returns the
 // concatenated contents downloaded from those URLs.
 func FromRegexLinks(pattern string) Transformer {
-	return func(buf []byte) []byte {
-		re, err := regexp.Compile(pattern)
-		if err != nil {
-			return []byte{}
-		}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return FromRaw
+	}
 
+	return func(buf []byte) []byte {
 		matches := re.FindAllSubmatch(buf, -1)
 		if len(matches) == 0 {
 			return []byte{}
@@ -88,9 +88,13 @@ func FromRegexLinks(pattern string) Transformer {
 			if err != nil {
 				continue
 			}
+			if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+				resp.Body.Close() // nolint: errcheck
+				continue
+			}
 			body, err := io.ReadAll(resp.Body)
 			resp.Body.Close() // nolint: errcheck
-			if err != nil || resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+			if err != nil {
 				continue
 			}
 

--- a/internal/transformer.go
+++ b/internal/transformer.go
@@ -17,8 +17,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	maxRegexLinkCount         = 32
+	maxRegexLinkResponseBytes = 10 * 1024 * 1024
+)
+
 var (
-	Transformers = map[string]Transformer{}
+	Transformers               = map[string]Transformer{}
+	allowPrivateRegexLinkHosts = false
 )
 
 func init() {
@@ -68,7 +74,7 @@ func FromRegexLinks(pattern string) Transformer {
 	}
 
 	return func(buf []byte) []byte {
-		matches := re.FindAllSubmatch(buf, -1)
+		matches := re.FindAllSubmatch(buf, maxRegexLinkCount)
 		if len(matches) == 0 {
 			return []byte{}
 		}
@@ -81,7 +87,7 @@ func FromRegexLinks(pattern string) Transformer {
 				link = match[1]
 			}
 			rawURL := strings.TrimSpace(string(link))
-			if _, ok := seen[rawURL]; ok || rawURL == "" {
+			if _, ok := seen[rawURL]; ok || !isAllowedRegexLink(rawURL) {
 				continue
 			}
 			seen[rawURL] = struct{}{}
@@ -94,9 +100,9 @@ func FromRegexLinks(pattern string) Transformer {
 				resp.Body.Close() // nolint: errcheck
 				continue
 			}
-			body, err := io.ReadAll(resp.Body)
+			body, err := io.ReadAll(io.LimitReader(resp.Body, maxRegexLinkResponseBytes+1))
 			resp.Body.Close() // nolint: errcheck
-			if err != nil {
+			if err != nil || len(body) > maxRegexLinkResponseBytes {
 				continue
 			}
 
@@ -106,6 +112,41 @@ func FromRegexLinks(pattern string) Transformer {
 
 		return result.Bytes()
 	}
+}
+
+func isAllowedRegexLink(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Hostname() == "" {
+		return false
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return false
+	}
+	if allowPrivateRegexLinkHosts {
+		return true
+	}
+
+	host := u.Hostname()
+	if strings.EqualFold(host, "localhost") {
+		return false
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return isPublicIP(ip)
+	}
+	ips, err := net.LookupIP(host)
+	if err != nil || len(ips) == 0 {
+		return false
+	}
+	for _, ip := range ips {
+		if !isPublicIP(ip) {
+			return false
+		}
+	}
+	return true
+}
+
+func isPublicIP(ip net.IP) bool {
+	return !ip.IsLoopback() && !ip.IsPrivate() && !ip.IsLinkLocalUnicast() && !ip.IsLinkLocalMulticast() && !ip.IsUnspecified()
 }
 
 // FlexPort handles YAML port values that may be int, float, or string.

--- a/internal/transformer.go
+++ b/internal/transformer.go
@@ -39,8 +39,8 @@ var (
 )
 
 func init() {
-	Transformers["base64"] = func(buf []byte, _ string) []byte { return FromBase64(buf) }
-	Transformers["clash"] = func(buf []byte, _ string) []byte { return FromClash(buf) }
+	Transformers["base64"] = FromBase64
+	Transformers["clash"] = FromClash
 	Transformers["link"] = FromLinks
 }
 
@@ -50,15 +50,13 @@ func RegisterTransformer(name string, t Transformer) {
 	Transformers[name] = t
 }
 
-func GetTransformer(spec string) Transformer {
+func GetTransformer(spec string) (Transformer, string) {
 	name, options := parseTransformerSpec(spec)
 	if t, ok := Transformers[name]; ok {
-		return func(buf []byte, _ string) []byte {
-			return t(buf, options)
-		}
+		return t, options
 	}
 
-	return func(buf []byte, _ string) []byte { return FromRaw(buf) }
+	return FromRaw, ""
 }
 
 func parseTransformerSpec(spec string) (string, string) {
@@ -66,11 +64,11 @@ func parseTransformerSpec(spec string) (string, string) {
 	return strings.TrimSpace(name), strings.TrimSpace(options)
 }
 
-func FromRaw(buf []byte) []byte {
+func FromRaw(buf []byte, _ string) []byte {
 	return buf
 }
 
-func FromBase64(buf []byte) []byte {
+func FromBase64(buf []byte, _ string) []byte {
 	decoded, err := base64.StdEncoding.DecodeString(string(buf))
 	if err != nil {
 		return buf
@@ -130,7 +128,7 @@ func FromLinks(buf []byte, spec string) []byte {
 
 func parseLinkSpec(spec string) (Transformer, string) {
 	if spec == "" {
-		return func(buf []byte, _ string) []byte { return FromRaw(buf) }, ""
+		return FromRaw, ""
 	}
 	if t, ok := Transformers[spec]; ok {
 		return t, ""
@@ -141,7 +139,7 @@ func parseLinkSpec(spec string) (Transformer, string) {
 			return t, strings.TrimPrefix(spec, prefix)
 		}
 	}
-	return func(buf []byte, _ string) []byte { return FromRaw(buf) }, spec
+	return FromRaw, spec
 }
 
 func isAllowedRegexLink(rawURL string) bool {
@@ -157,11 +155,11 @@ func isAllowedRegexLink(rawURL string) bool {
 	}
 
 	host := u.Hostname()
-	if strings.EqualFold(host, "localhost") {
+	if strings.EqualFold(host, "localhost") || IsLocal(host) {
 		return false
 	}
 	if ip := net.ParseIP(host); ip != nil {
-		return isPublicIP(ip)
+		return !IsLocal(ip.String()) && isPublicIP(ip)
 	}
 	ips, err := net.LookupIP(host)
 	if err != nil || len(ips) == 0 {
@@ -280,7 +278,7 @@ type ClashConfig struct {
 }
 
 // FromClash parses a Clash YAML config and extracts proxy URLs.
-func FromClash(buf []byte) []byte {
+func FromClash(buf []byte, _ string) []byte {
 	// Limit YAML size to prevent OOM attacks (10MB max)
 	const maxYAMLSize = 10 * 1024 * 1024
 	if len(buf) > maxYAMLSize {

--- a/internal/transformer_test.go
+++ b/internal/transformer_test.go
@@ -1033,6 +1033,14 @@ func TestGetTransformerRegex(t *testing.T) {
 	}
 }
 
+func TestGetTransformerRegexInvalidPattern(t *testing.T) {
+	transformer := GetTransformer(`regex:(https?://[^\s]+\.txt`)
+	got := string(transformer([]byte("http://1.2.3.4:8080\n")))
+	if got != "" {
+		t.Fatalf("expected empty output for invalid regex, got %q", got)
+	}
+}
+
 // TestFlexPortFloatRejection locks the contract that float ports must be
 // integral, finite, and within the valid TCP/UDP range. Catches CodeRabbit's
 // concern that int(f) silently truncates non-integer floats and accepts

--- a/internal/transformer_test.go
+++ b/internal/transformer_test.go
@@ -3,6 +3,8 @@ package internal
 import (
 	"encoding/base64"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -54,8 +56,8 @@ socks-port: 7891`,
 			expected: "",
 		},
 		{
-			name: "empty input",
-			input: "",
+			name:     "empty input",
+			input:    "",
 			expected: "",
 		},
 		{
@@ -281,15 +283,15 @@ socks-port: 7891`,
 		{
 			// 10MB is the maxYAMLSize boundary: input passes the size gate and
 			// reaches the YAML parser, which fails on non-YAML content, so output is empty.
-			name: "input at 10MB size limit reaches parser and yields empty output on parse failure",
-			input: strings.Repeat("x", 10*1024*1024),
+			name:     "input at 10MB size limit reaches parser and yields empty output on parse failure",
+			input:    strings.Repeat("x", 10*1024*1024),
 			expected: "",
 		},
 		{
 			// 11MB exceeds maxYAMLSize: input is rejected by the size gate
 			// before YAML parsing, so output is empty without a parse attempt.
-			name: "input above 10MB size limit rejected by size gate before parsing",
-			input: strings.Repeat("x", 11*1024*1024), // 11MB
+			name:     "input above 10MB size limit rejected by size gate before parsing",
+			input:    strings.Repeat("x", 11*1024*1024), // 11MB
 			expected: "",
 		},
 	}
@@ -993,6 +995,37 @@ func parseVlessTestURL(rawURL string) (*url.URL, error) {
 // parseTrojanTestURL parses a trojan:// URL for test assertions.
 func parseTrojanTestURL(rawURL string) (*url.URL, error) {
 	return url.Parse(rawURL)
+}
+
+func TestFromRegexLinks(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/one.txt":
+			_, _ = w.Write([]byte("http://1.2.3.4:8080\n"))
+		case "/two.txt":
+			_, _ = w.Write([]byte("socks5://5.6.7.8:1080\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	readme := []byte("sources:\n- " + server.URL + "/one.txt\n- " + server.URL + "/two.txt\n")
+	transformer := FromRegexLinks(`(https?://[^\s]+\.txt)`)
+
+	got := string(transformer(readme))
+	want := "http://1.2.3.4:8080\nsocks5://5.6.7.8:1080\n"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestGetTransformerRegex(t *testing.T) {
+	transformer := GetTransformer(`regex:(https?://[^\s]+\.txt)`)
+	got := string(transformer([]byte("no matching URLs")))
+	if got != "" {
+		t.Fatalf("expected empty output for no matches, got %q", got)
+	}
 }
 
 // TestFlexPortFloatRejection locks the contract that float ports must be

--- a/internal/transformer_test.go
+++ b/internal/transformer_test.go
@@ -998,30 +998,48 @@ func parseTrojanTestURL(rawURL string) (*url.URL, error) {
 }
 
 func TestFromRegexLinks(t *testing.T) {
-	requests := map[string]int{}
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requests[r.URL.Path]++
-		switch r.URL.Path {
-		case "/one.txt":
-			_, _ = w.Write([]byte("http://1.2.3.4:8080\n"))
-		case "/two.txt":
-			_, _ = w.Write([]byte("socks5://5.6.7.8:1080\n"))
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer server.Close()
-
-	readme := []byte("sources:\n- " + server.URL + "/one.txt\n- " + server.URL + "/two.txt\n- " + server.URL + "/one.txt\n")
-	transformer := FromRegexLinks(`(https?://[^\s]+\.txt)`)
-
-	got := string(transformer(readme))
-	want := "http://1.2.3.4:8080\nsocks5://5.6.7.8:1080\n"
-	if got != want {
-		t.Fatalf("expected %q, got %q", want, got)
+	tests := []struct {
+		name    string
+		pattern string
+	}{
+		{
+			name:    "capturing group",
+			pattern: `(https?://[^\s]+\.txt)`,
+		},
+		{
+			name:    "whole match",
+			pattern: `https?://[^\s]+\.txt`,
+		},
 	}
-	if requests["/one.txt"] != 1 {
-		t.Fatalf("expected duplicate link to be fetched once, got %d requests", requests["/one.txt"])
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requests := map[string]int{}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests[r.URL.Path]++
+				switch r.URL.Path {
+				case "/one.txt":
+					_, _ = w.Write([]byte("http://1.2.3.4:8080\n"))
+				case "/two.txt":
+					_, _ = w.Write([]byte("socks5://5.6.7.8:1080\n"))
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			readme := []byte("sources:\n- " + server.URL + "/one.txt\n- " + server.URL + "/two.txt\n- " + server.URL + "/one.txt\n")
+			transformer := FromRegexLinks(tt.pattern)
+
+			got := string(transformer(readme))
+			want := "http://1.2.3.4:8080\nsocks5://5.6.7.8:1080\n"
+			if got != want {
+				t.Fatalf("expected %q, got %q", want, got)
+			}
+			if requests["/one.txt"] != 1 {
+				t.Fatalf("expected duplicate link to be fetched once, got %d requests", requests["/one.txt"])
+			}
+		})
 	}
 }
 

--- a/internal/transformer_test.go
+++ b/internal/transformer_test.go
@@ -1069,6 +1069,18 @@ func TestFromLinksAppliesKeywordBeforeFanOutLimit(t *testing.T) {
 	}
 }
 
+func TestRegexLinkRedirectsRejectPrivateTargets(t *testing.T) {
+	allowPrivateRegexLinkHosts = false
+
+	req, err := http.NewRequest(http.MethodGet, "http://169.254.169.254/latest/meta-data", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := regexLinkClient.CheckRedirect(req, nil); err == nil {
+		t.Fatal("expected private redirect target to be rejected")
+	}
+}
+
 func TestFromLinksRejectsPrivateTargets(t *testing.T) {
 	allowPrivateRegexLinkHosts = false
 

--- a/internal/transformer_test.go
+++ b/internal/transformer_test.go
@@ -998,7 +998,9 @@ func parseTrojanTestURL(rawURL string) (*url.URL, error) {
 }
 
 func TestFromRegexLinks(t *testing.T) {
+	requests := map[string]int{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests[r.URL.Path]++
 		switch r.URL.Path {
 		case "/one.txt":
 			_, _ = w.Write([]byte("http://1.2.3.4:8080\n"))
@@ -1010,13 +1012,16 @@ func TestFromRegexLinks(t *testing.T) {
 	}))
 	defer server.Close()
 
-	readme := []byte("sources:\n- " + server.URL + "/one.txt\n- " + server.URL + "/two.txt\n")
+	readme := []byte("sources:\n- " + server.URL + "/one.txt\n- " + server.URL + "/two.txt\n- " + server.URL + "/one.txt\n")
 	transformer := FromRegexLinks(`(https?://[^\s]+\.txt)`)
 
 	got := string(transformer(readme))
 	want := "http://1.2.3.4:8080\nsocks5://5.6.7.8:1080\n"
 	if got != want {
 		t.Fatalf("expected %q, got %q", want, got)
+	}
+	if requests["/one.txt"] != 1 {
+		t.Fatalf("expected duplicate link to be fetched once, got %d requests", requests["/one.txt"])
 	}
 }
 

--- a/internal/transformer_test.go
+++ b/internal/transformer_test.go
@@ -1022,7 +1022,7 @@ func TestFromLinksDownloadsKeywordMatchesAndAppliesTransformer(t *testing.T) {
 	readme := []byte("sources:\n- " + server.URL + "/base64-fn0618.txt\n- " + server.URL + "/other.txt\n- " + server.URL + "/base64-fn0618.txt\n")
 	transformer := GetTransformer("link:base64-fn0618")
 
-	got := string(transformer(readme))
+	got := string(transformer(readme, ""))
 	want := "http://1.2.3.4:8080\n"
 	if got != want {
 		t.Fatalf("expected %q, got %q", want, got)
@@ -1035,10 +1035,37 @@ func TestFromLinksDownloadsKeywordMatchesAndAppliesTransformer(t *testing.T) {
 	}
 
 	clashTransformer := GetTransformer("link:clash-fn0618")
-	got = string(clashTransformer([]byte("source: " + server.URL + "/clash-fn0618.yaml\n")))
+	got = string(clashTransformer([]byte("source: "+server.URL+"/clash-fn0618.yaml\n"), ""))
 	want = "socks5://5.6.7.8:1080\n"
 	if got != want {
 		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestFromLinksAppliesKeywordBeforeFanOutLimit(t *testing.T) {
+	allowPrivateRegexLinkHosts = true
+	defer func() { allowPrivateRegexLinkHosts = false }()
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		_, _ = w.Write([]byte("http://1.2.3.4:8080\n"))
+	}))
+	defer server.Close()
+
+	links := make([]string, 0, maxRegexLinkCount+1)
+	for i := 0; i < maxRegexLinkCount; i++ {
+		links = append(links, fmt.Sprintf("%s/asset-%d.css", server.URL, i))
+	}
+	links = append(links, server.URL+"/proxy-fn0618.txt")
+
+	transformer := GetTransformer("link:fn0618")
+	got := string(transformer([]byte(strings.Join(links, "\n")), ""))
+	if got != "http://1.2.3.4:8080\n" {
+		t.Fatalf("expected keyword link after non-keyword matches to be fetched, got %q", got)
+	}
+	if requests != 1 {
+		t.Fatalf("expected only keyword link to be fetched, got %d requests", requests)
 	}
 }
 
@@ -1053,7 +1080,7 @@ func TestFromLinksRejectsPrivateTargets(t *testing.T) {
 	defer server.Close()
 
 	transformer := GetTransformer("link:private")
-	got := string(transformer([]byte("source: " + server.URL + "/private.txt\n")))
+	got := string(transformer([]byte("source: "+server.URL+"/private.txt\n"), ""))
 	if got != "" {
 		t.Fatalf("expected private target to be skipped, got %q", got)
 	}
@@ -1084,7 +1111,7 @@ func TestFromLinksLimitsFanOutAndBodySize(t *testing.T) {
 	links[0] = server.URL + "/oversize.txt?tag=fn0618"
 
 	transformer := GetTransformer("link:fn0618")
-	got := string(transformer([]byte(strings.Join(links, "\n"))))
+	got := string(transformer([]byte(strings.Join(links, "\n")), ""))
 	if strings.Contains(got, strings.Repeat("x", 32)) {
 		t.Fatalf("expected oversized response to be skipped")
 	}

--- a/internal/transformer_test.go
+++ b/internal/transformer_test.go
@@ -299,7 +299,7 @@ socks-port: 7891`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := string(FromClash([]byte(tt.input)))
+			result := string(FromClash([]byte(tt.input), ""))
 			if result != tt.expected {
 				t.Errorf("FromClash() = %q, want %q", result, tt.expected)
 			}
@@ -384,7 +384,7 @@ func TestVmessURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := string(FromClash([]byte(tt.input)))
+			result := string(FromClash([]byte(tt.input), ""))
 			if tt.name == "vmess missing uuid skipped" {
 				if result != "" {
 					t.Errorf("expected empty result for missing uuid, got %q", result)
@@ -647,7 +647,7 @@ func TestVlessURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := string(FromClash([]byte(tt.input)))
+			result := string(FromClash([]byte(tt.input), ""))
 
 			if tt.checkURL == nil {
 				if result != "" {
@@ -907,7 +907,7 @@ func TestTrojanURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := string(FromClash([]byte(tt.input)))
+			result := string(FromClash([]byte(tt.input), ""))
 
 			if tt.checkURL == nil {
 				if result != "" {
@@ -961,7 +961,7 @@ func TestMixedProtocols(t *testing.T) {
     server: 5.6.7.8
     port: 1080`
 
-	result := string(FromClash([]byte(input)))
+	result := string(FromClash([]byte(input), ""))
 	lines := strings.Split(strings.TrimSpace(result), "\n")
 
 	if len(lines) != 6 {
@@ -1020,9 +1020,9 @@ func TestFromLinksDownloadsKeywordMatchesAndAppliesTransformer(t *testing.T) {
 	defer server.Close()
 
 	readme := []byte("sources:\n- " + server.URL + "/base64-fn0618.txt\n- " + server.URL + "/other.txt\n- " + server.URL + "/base64-fn0618.txt\n")
-	transformer := GetTransformer("link:base64-fn0618")
+	transformer, transformerOptions := GetTransformer("link:base64-fn0618")
 
-	got := string(transformer(readme, ""))
+	got := string(transformer(readme, transformerOptions))
 	want := "http://1.2.3.4:8080\n"
 	if got != want {
 		t.Fatalf("expected %q, got %q", want, got)
@@ -1034,8 +1034,8 @@ func TestFromLinksDownloadsKeywordMatchesAndAppliesTransformer(t *testing.T) {
 		t.Fatalf("expected non-keyword link not to be fetched, got %d requests", requests["/other.txt"])
 	}
 
-	clashTransformer := GetTransformer("link:clash-fn0618")
-	got = string(clashTransformer([]byte("source: "+server.URL+"/clash-fn0618.yaml\n"), ""))
+	clashTransformer, clashTransformerOptions := GetTransformer("link:clash-fn0618")
+	got = string(clashTransformer([]byte("source: "+server.URL+"/clash-fn0618.yaml\n"), clashTransformerOptions))
 	want = "socks5://5.6.7.8:1080\n"
 	if got != want {
 		t.Fatalf("expected %q, got %q", want, got)
@@ -1059,8 +1059,8 @@ func TestFromLinksAppliesKeywordBeforeFanOutLimit(t *testing.T) {
 	}
 	links = append(links, server.URL+"/proxy-fn0618.txt")
 
-	transformer := GetTransformer("link:fn0618")
-	got := string(transformer([]byte(strings.Join(links, "\n")), ""))
+	transformer, transformerOptions := GetTransformer("link:fn0618")
+	got := string(transformer([]byte(strings.Join(links, "\n")), transformerOptions))
 	if got != "http://1.2.3.4:8080\n" {
 		t.Fatalf("expected keyword link after non-keyword matches to be fetched, got %q", got)
 	}
@@ -1091,8 +1091,8 @@ func TestFromLinksRejectsPrivateTargets(t *testing.T) {
 	}))
 	defer server.Close()
 
-	transformer := GetTransformer("link:private")
-	got := string(transformer([]byte("source: "+server.URL+"/private.txt\n"), ""))
+	transformer, transformerOptions := GetTransformer("link:private")
+	got := string(transformer([]byte("source: "+server.URL+"/private.txt\n"), transformerOptions))
 	if got != "" {
 		t.Fatalf("expected private target to be skipped, got %q", got)
 	}
@@ -1122,8 +1122,8 @@ func TestFromLinksLimitsFanOutAndBodySize(t *testing.T) {
 	}
 	links[0] = server.URL + "/oversize.txt?tag=fn0618"
 
-	transformer := GetTransformer("link:fn0618")
-	got := string(transformer([]byte(strings.Join(links, "\n")), ""))
+	transformer, transformerOptions := GetTransformer("link:fn0618")
+	got := string(transformer([]byte(strings.Join(links, "\n")), transformerOptions))
 	if strings.Contains(got, strings.Repeat("x", 32)) {
 		t.Fatalf("expected oversized response to be skipped")
 	}
@@ -1159,7 +1159,7 @@ func TestFlexPortFloatRejection(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			yaml := "proxies:\n  - name: test\n    type: http\n    server: example.com\n    port: " + tt.yamlPort + "\n"
-			result := string(FromClash([]byte(yaml)))
+			result := string(FromClash([]byte(yaml), ""))
 			if tt.wantEmpty && result != "" {
 				t.Errorf("port %q: expected empty result, got %q", tt.yamlPort, result)
 			}

--- a/internal/transformer_test.go
+++ b/internal/transformer_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -998,6 +999,9 @@ func parseTrojanTestURL(rawURL string) (*url.URL, error) {
 }
 
 func TestFromRegexLinks(t *testing.T) {
+	allowPrivateRegexLinkHosts = true
+	defer func() { allowPrivateRegexLinkHosts = false }()
+
 	tests := []struct {
 		name    string
 		pattern string
@@ -1040,6 +1044,57 @@ func TestFromRegexLinks(t *testing.T) {
 				t.Fatalf("expected duplicate link to be fetched once, got %d requests", requests["/one.txt"])
 			}
 		})
+	}
+}
+
+func TestFromRegexLinksRejectsPrivateTargets(t *testing.T) {
+	allowPrivateRegexLinkHosts = false
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		_, _ = w.Write([]byte("http://1.2.3.4:8080\n"))
+	}))
+	defer server.Close()
+
+	transformer := FromRegexLinks(`https?://[^\s]+\.txt`)
+	got := string(transformer([]byte("source: " + server.URL + "/private.txt\n")))
+	if got != "" {
+		t.Fatalf("expected private target to be skipped, got %q", got)
+	}
+	if requests != 0 {
+		t.Fatalf("expected private target not to be requested, got %d requests", requests)
+	}
+}
+
+func TestFromRegexLinksLimitsFanOutAndBodySize(t *testing.T) {
+	allowPrivateRegexLinkHosts = true
+	defer func() { allowPrivateRegexLinkHosts = false }()
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.Path == "/oversize.txt" {
+			_, _ = w.Write([]byte(strings.Repeat("x", maxRegexLinkResponseBytes+1)))
+			return
+		}
+		_, _ = w.Write([]byte("http://1.2.3.4:8080\n"))
+	}))
+	defer server.Close()
+
+	links := make([]string, 0, maxRegexLinkCount+2)
+	for i := 0; i < maxRegexLinkCount+1; i++ {
+		links = append(links, fmt.Sprintf("%s/%d.txt", server.URL, i))
+	}
+	links[0] = server.URL + "/oversize.txt"
+
+	transformer := FromRegexLinks(`https?://[^\s]+\.txt`)
+	got := string(transformer([]byte(strings.Join(links, "\n"))))
+	if strings.Contains(got, strings.Repeat("x", 32)) {
+		t.Fatalf("expected oversized response to be skipped")
+	}
+	if requests != maxRegexLinkCount {
+		t.Fatalf("expected at most %d requests, got %d", maxRegexLinkCount, requests)
 	}
 }
 

--- a/internal/transformer_test.go
+++ b/internal/transformer_test.go
@@ -998,56 +998,51 @@ func parseTrojanTestURL(rawURL string) (*url.URL, error) {
 	return url.Parse(rawURL)
 }
 
-func TestFromRegexLinks(t *testing.T) {
+func TestFromLinksDownloadsKeywordMatchesAndAppliesTransformer(t *testing.T) {
 	allowPrivateRegexLinkHosts = true
 	defer func() { allowPrivateRegexLinkHosts = false }()
 
-	tests := []struct {
-		name    string
-		pattern string
-	}{
-		{
-			name:    "capturing group",
-			pattern: `(https?://[^\s]+\.txt)`,
-		},
-		{
-			name:    "whole match",
-			pattern: `https?://[^\s]+\.txt`,
-		},
+	requests := map[string]int{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests[r.URL.Path]++
+		switch r.URL.Path {
+		case "/base64-fn0618.txt":
+			encoded := base64.StdEncoding.EncodeToString([]byte("http://1.2.3.4:8080\n"))
+			_, _ = w.Write([]byte(encoded))
+		case "/clash-fn0618.yaml":
+			_, _ = w.Write([]byte("proxies:\n  - name: socks\n    type: socks5\n    server: 5.6.7.8\n    port: 1080\n"))
+		case "/other.txt":
+			_, _ = w.Write([]byte("http://9.9.9.9:9090\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	readme := []byte("sources:\n- " + server.URL + "/base64-fn0618.txt\n- " + server.URL + "/other.txt\n- " + server.URL + "/base64-fn0618.txt\n")
+	transformer := GetTransformer("link:base64-fn0618")
+
+	got := string(transformer(readme))
+	want := "http://1.2.3.4:8080\n"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+	if requests["/base64-fn0618.txt"] != 1 {
+		t.Fatalf("expected duplicate keyword link to be fetched once, got %d requests", requests["/base64-fn0618.txt"])
+	}
+	if requests["/other.txt"] != 0 {
+		t.Fatalf("expected non-keyword link not to be fetched, got %d requests", requests["/other.txt"])
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			requests := map[string]int{}
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				requests[r.URL.Path]++
-				switch r.URL.Path {
-				case "/one.txt":
-					_, _ = w.Write([]byte("http://1.2.3.4:8080\n"))
-				case "/two.txt":
-					_, _ = w.Write([]byte("socks5://5.6.7.8:1080\n"))
-				default:
-					http.NotFound(w, r)
-				}
-			}))
-			defer server.Close()
-
-			readme := []byte("sources:\n- " + server.URL + "/one.txt\n- " + server.URL + "/two.txt\n- " + server.URL + "/one.txt\n")
-			transformer := FromRegexLinks(tt.pattern)
-
-			got := string(transformer(readme))
-			want := "http://1.2.3.4:8080\nsocks5://5.6.7.8:1080\n"
-			if got != want {
-				t.Fatalf("expected %q, got %q", want, got)
-			}
-			if requests["/one.txt"] != 1 {
-				t.Fatalf("expected duplicate link to be fetched once, got %d requests", requests["/one.txt"])
-			}
-		})
+	clashTransformer := GetTransformer("link:clash-fn0618")
+	got = string(clashTransformer([]byte("source: " + server.URL + "/clash-fn0618.yaml\n")))
+	want = "socks5://5.6.7.8:1080\n"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
 	}
 }
 
-func TestFromRegexLinksRejectsPrivateTargets(t *testing.T) {
+func TestFromLinksRejectsPrivateTargets(t *testing.T) {
 	allowPrivateRegexLinkHosts = false
 
 	requests := 0
@@ -1057,7 +1052,7 @@ func TestFromRegexLinksRejectsPrivateTargets(t *testing.T) {
 	}))
 	defer server.Close()
 
-	transformer := FromRegexLinks(`https?://[^\s]+\.txt`)
+	transformer := GetTransformer("link:private")
 	got := string(transformer([]byte("source: " + server.URL + "/private.txt\n")))
 	if got != "" {
 		t.Fatalf("expected private target to be skipped, got %q", got)
@@ -1067,7 +1062,7 @@ func TestFromRegexLinksRejectsPrivateTargets(t *testing.T) {
 	}
 }
 
-func TestFromRegexLinksLimitsFanOutAndBodySize(t *testing.T) {
+func TestFromLinksLimitsFanOutAndBodySize(t *testing.T) {
 	allowPrivateRegexLinkHosts = true
 	defer func() { allowPrivateRegexLinkHosts = false }()
 
@@ -1084,33 +1079,17 @@ func TestFromRegexLinksLimitsFanOutAndBodySize(t *testing.T) {
 
 	links := make([]string, 0, maxRegexLinkCount+2)
 	for i := 0; i < maxRegexLinkCount+1; i++ {
-		links = append(links, fmt.Sprintf("%s/%d.txt", server.URL, i))
+		links = append(links, fmt.Sprintf("%s/fn0618-%d.txt", server.URL, i))
 	}
-	links[0] = server.URL + "/oversize.txt"
+	links[0] = server.URL + "/oversize.txt?tag=fn0618"
 
-	transformer := FromRegexLinks(`https?://[^\s]+\.txt`)
+	transformer := GetTransformer("link:fn0618")
 	got := string(transformer([]byte(strings.Join(links, "\n"))))
 	if strings.Contains(got, strings.Repeat("x", 32)) {
 		t.Fatalf("expected oversized response to be skipped")
 	}
 	if requests != maxRegexLinkCount {
 		t.Fatalf("expected at most %d requests, got %d", maxRegexLinkCount, requests)
-	}
-}
-
-func TestGetTransformerRegex(t *testing.T) {
-	transformer := GetTransformer(`regex:(https?://[^\s]+\.txt)`)
-	got := string(transformer([]byte("no matching URLs")))
-	if got != "" {
-		t.Fatalf("expected empty output for no matches, got %q", got)
-	}
-}
-
-func TestGetTransformerRegexInvalidPattern(t *testing.T) {
-	transformer := GetTransformer(`regex:(https?://[^\s]+\.txt`)
-	got := string(transformer([]byte("http://1.2.3.4:8080\n")))
-	if got != "" {
-		t.Fatalf("expected empty output for invalid regex, got %q", got)
 	}
 }
 

--- a/sources/auto.txt
+++ b/sources/auto.txt
@@ -1,3 +1,4 @@
+https://github.com/crashgfw/free-airport-nodes,link:base64-fn0618
 https://github.com/LalatinaHub/Mineral/raw/refs/heads/master/result/nodes
 https://github.com/4n0nymou3/multi-proxy-config-fetcher/raw/refs/heads/main/configs/proxy_configs.txt
 https://github.com/freefq/free/raw/refs/heads/master/v2,base64,


### PR DESCRIPTION
## Summary
- add a `link[:transformer-keyword]` transformer that extracts linked proxy-list URLs from documents, downloads each unique matching link, and merges the transformed content before parsing
- route transformer options through generic `name[:options]` handling instead of special-casing `link:` lookup
- add a real source entry for `https://github.com/crashgfw/free-airport-nodes,link:base64-fn0618`
- document transformer option syntax and add regression coverage for merged downloads, dedupe, private-target rejection, limits, and keyword filtering before the fetch cap

## Testing
- [x] `go test ./internal -run 'TestFromLinks|TestGetTransformer' -count=1`
- [x] `go test ./... -count=1`
- [x] `make test`
- [x] `make lint`
- [x] `make build`

Closes #23
