### PR TITLE
chore: add VPSLab proxy sources

### DIFF
--- a/sources/http.txt
+++ b/sources/http.txt
@@ -77,3 +77,11 @@ https://github.com/proxygenerator1/ProxyGenerator/raw/refs/heads/main/Unstable/h
 https://github.com/proxygenerator1/ProxyGenerator/raw/refs/heads/main/Unstable/https.txt
 https://github.com/proxygenerator1/ProxyGenerator/raw/refs/heads/main/Stable/http.txt
 https://github.com/proxygenerator1/ProxyGenerator/raw/refs/heads/main/Stable/https.txt
+https://raw.githubusercontent.com/VPSLabCloud/VPSLab-Free-Proxy-List/refs/heads/main/http_all.txt
+https://raw.githubusercontent.com/VPSLabCloud/VPSLab-Free-Proxy-List/refs/heads/main/http_ssl.txt
+https://raw.githubusercontent.com/VPSLabCloud/VPSLab-Free-Proxy-List/refs/heads/main/http_nossl.txt
+https://raw.githubusercontent.com/VPSLabCloud/VPSLab-Free-Proxy-List/refs/heads/main/http_elite.txt
+https://raw.githubusercontent.com/VPSLabCloud/VPSLab-Free-Proxy-List/refs/heads/main/http_anonymous.txt
+https://raw.githubusercontent.com/VPSLabCloud/VPSLab-Free-Proxy-List/refs/heads/main/http_transparent.txt
+https://raw.githubusercontent.com/VPSLabCloud/VPSLab-Free-Proxy-List/refs/heads/main/http_ssl_elite.txt
+https://raw.githubusercontent.com/VPSLabCloud/VPSLab-Free-Proxy-List/refs/heads/main/http_ssl_anonymous.txt

--- a/sources/https.txt
+++ b/sources/https.txt
@@ -65,3 +65,11 @@ https://github.com/proxygenerator1/ProxyGenerator/raw/refs/heads/main/Stable/htt
 https://github.com/proxygenerator1/ProxyGenerator/raw/refs/heads/main/Stable/https.txt
 https://github.com/proxygenerator1/ProxyGenerator/raw/refs/heads/main/Unstable/http.txt
 https://github.com/proxygenerator1/ProxyGenerator/raw/refs/heads/main/Unstable/https.txt
+https://raw.githubusercontent.com/VPSLabCloud/VPSLab-Free-Proxy-List/refs/heads/main/http_all.txt
+https://raw.githubusercontent.com/VPSLabCloud/VPSLab-Free-Proxy-List/refs/heads/main/http_ssl.txt
+https://raw.githubusercontent.com/VPSLabCloud/VPSLab-Free-Proxy-List/refs/heads/main/http_nossl.txt
+https://raw.githubusercontent.com/VPSLabCloud/VPSLab-Free-Proxy-List/refs/heads/main/http_elite.txt
+https://raw.githubusercontent.com/VPSLabCloud/VPSLab-Free-Proxy-List/refs/heads/main/http_anonymous.txt
+https://raw.githubusercontent.com/VPSLabCloud/VPSLab-Free-Proxy-List/refs/heads/main/http_transparent.txt
+https://raw.githubusercontent.com/VPSLabCloud/VPSLab-Free-Proxy-List/refs/heads/main/http_ssl_elite.txt
+https://raw.githubusercontent.com/VPSLabCloud/VPSLab-Free-Proxy-List/refs/heads/main/http_ssl_anonymous.txt

--- a/sources/socks4.txt
+++ b/sources/socks4.txt
@@ -56,3 +56,5 @@ https://github.com/Thordata/awesome-free-proxy-list/raw/refs/heads/main/proxies/
 https://raw.githubusercontent.com/fyvri/fresh-proxy-list/archive/storage/classic/socks4.txt
 https://github.com/proxygenerator1/ProxyGenerator/raw/refs/heads/main/Stable/socks4.txt
 https://github.com/proxygenerator1/ProxyGenerator/raw/refs/heads/main/Unstable/socks4.txt
+https://raw.githubusercontent.com/VPSLabCloud/VPSLab-Free-Proxy-List/refs/heads/main/socks4_all.txt
+

--- a/sources/socks5.txt
+++ b/sources/socks5.txt
@@ -57,3 +57,4 @@ https://github.com/Thordata/awesome-free-proxy-list/raw/refs/heads/main/proxies/
 https://raw.githubusercontent.com/fyvri/fresh-proxy-list/archive/storage/classic/socks5.txt
 https://github.com/proxygenerator1/ProxyGenerator/raw/refs/heads/main/Stable/socks5.txt
 https://github.com/proxygenerator1/ProxyGenerator/raw/refs/heads/main/Unstable/socks5.txt
+https://raw.githubusercontent.com/VPSLabCloud/VPSLab-Free-Proxy-List/refs/heads/main/socks5_all.txt


### PR DESCRIPTION
## Summary
- add VPSLab proxy source URLs for HTTP, HTTPS, SOCKS4, and SOCKS5 lists

## Testing
- verified the repository changes and pushed the branch successfully

## Summary by Sourcery

Chores:
- Populate HTTP, HTTPS, SOCKS4, and SOCKS5 source files with VPSLab proxy list URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the available proxy source list with additional HTTP, HTTPS, SOCKS4, and SOCKS5 upstream feeds.
  * Added multiple new proxy variants to improve source coverage across different connection types and anonymity levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->