### PR TITLE
docs: fix subject-verb agreement in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ The core of this project is the collection of proxy sources. We are always looki
 
 **How it works:**
 
-The application reads files from the `/sources` directory. Each file in this directory (e.g., `http.txt`, `vless.txt`) corresponds to a proxy protocol. The content of these files are URLs, with each URL pointing to a list of proxies.
+The application reads files from the `/sources` directory. Each file in this directory (e.g., `http.txt`, `vless.txt`) corresponds to a proxy protocol. The contents of these files are URLs, with each URL pointing to a list of proxies.
 
 **Steps to add a source:**
 


### PR DESCRIPTION
## Description
This PR fixes subject-verb agreement in `CONTRIBUTING.md`.

## Details
Updated `The content of these files are URLs` -> `The contents of these files are URLs` under proxy sources documentation.

## Summary by Sourcery

Documentation:
- Fix subject-verb agreement in CONTRIBUTING.md when describing contents of proxy source files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected grammar in the contributor guidance for adding new proxy sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->