### PR TITLE
docs: fix Protocol spelling typo in README.md link text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Even if you don't have time to contribute code, there are other ways you can sup
 
 1.  Ensure any install or build dependencies are removed before the end of the layer when doing a build.
 2.  Update the `README.md` with details of changes to the interface, this includes new environment variables, exposed ports, useful file locations, and container parameters.
-3.  Increase the version numbers in any examples and the `README.md` to the new version that this Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
+3.  Increase the version numbers in any examples and the `README.md` to the new version that this Pull Request would represent. The versioning scheme we use is [SemVer](https://semver.org/).
 4.  You may merge the Pull Request in once you have the sign-off of two other developers, or if you do not have permission to do that, you may request the second reviewer to merge it for you.
 
 ## Getting Started: Your First Contribution
@@ -37,7 +37,7 @@ The core of this project is the collection of proxy sources. We are always looki
 
 **How it works:**
 
-The application reads files from the `/sources` directory. Each file in this directory (e.g., `http.txt`, `vless.txt`) corresponds to a proxy protocol. The contents of these files are URLs, with each URL pointing to a list of proxies.
+The application reads files from the `sources/` directory. Each file in this directory (e.g., `http.txt`, `vless.txt`) corresponds to a proxy protocol. The contents of these files are URLs, with each URL pointing to a list of proxies.
 
 **Steps to add a source:**
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   
   <br>
   <br>
-  <a href="https://getfreeproxy.com/lists/" title="free working proxy list">Working Proxy List</a> | <a href="https://getfreeproxy.com/tools/proxy-checker" title="free online proxy checker">Free Proxy Checker</a> | <a href="https://getfreeproxy.com/tools/proxy-protocol-parser" title="free online proxy protocol parser">Universal Proxy Procotol Parser</a>| <a href="https://developer.getfreeproxy.com/" title="free proxy api">Free Proxy API</a>
+  <a href="https://getfreeproxy.com/lists/" title="free working proxy list">Working Proxy List</a> | <a href="https://getfreeproxy.com/tools/proxy-checker" title="free online proxy checker">Free Proxy Checker</a> | <a href="https://getfreeproxy.com/tools/proxy-protocol-parser" title="free online proxy protocol parser">Universal Proxy Protocol Parser</a>| <a href="https://developer.getfreeproxy.com/" title="free proxy api">Free Proxy API</a>
   <br>
 </p>
 


### PR DESCRIPTION
## Description
This PR fixes a spelling typo in the HTML header links of `README.md`.

## Details
Corrected word spelling (`Procotol` $\to$ `Protocol`).

## Summary by Sourcery

Correct documentation typos and links in CONTRIBUTING and README.

Documentation:
- Fix the spelling of the "Universal Proxy Protocol Parser" link text in README header.
- Update CONTRIBUTING instructions to reference the correct SemVer HTTPS URL and adjust the sources directory path description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the contribution guide to use the secure SemVer link.
  * Clarified the directory path for adding new proxy sources.
  * Corrected a spelling error in the Universal Proxy Protocol Parser link label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->